### PR TITLE
Add unit tests to app shell components

### DIFF
--- a/packages/lib/src/components/common/Footer/CommonFooter.test.tsx
+++ b/packages/lib/src/components/common/Footer/CommonFooter.test.tsx
@@ -1,19 +1,25 @@
-import { render, screen } from '@testing-library/react'
-import { describe, expect, it, vi } from 'vitest'
+import { render, RenderResult, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CommonFooter } from './CommonFooter'
 
-vi.mock('react-i18next', () => {
-  return {
-    useTranslation: () => ({
-      t: (key: unknown) => key,
-    }),
-  }
-})
-
 describe('CommonFooter', () => {
-  it('should render the footer', () => {
-    render(<CommonFooter />)
+  let CommonFooterMounted: RenderResult
+
+  beforeEach(() => {
+    vi.mock('react-i18next', () => ({
+      useTranslation: () => {
+        return {
+          t: (str: unknown) => str,
+        }
+      },
+    }))
+
+    CommonFooterMounted = render(<CommonFooter />)
+  })
+
+  afterEach(() => {
+    CommonFooterMounted.unmount()
   })
 
   it('should contain the correct content', () => {

--- a/packages/lib/src/components/common/Header/CommonHeader.test.tsx
+++ b/packages/lib/src/components/common/Header/CommonHeader.test.tsx
@@ -1,18 +1,40 @@
-import { render } from '@testing-library/react'
-import { describe, it, vi } from 'vitest'
+import { render, RenderResult, screen } from '@testing-library/react'
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CommonHeader } from './CommonHeader'
-
-vi.mock('react-i18next', () => {
-  return {
-    useTranslation: () => ({
-      t: (key: unknown) => key,
-    }),
-  }
-})
+import { SearchBar, UserMenu } from './components'
 
 describe('CommonHeader', () => {
-  it('should render the header', () => {
-    render(<CommonHeader isOpen handleOpenNav={() => {}} />)
+  let CommonHeaderMounted: RenderResult
+
+  beforeEach(() => {
+    vi.mock('react-i18next', () => ({
+      useTranslation: () => {
+        return {
+          t: (str: unknown) => str,
+        }
+      },
+    }))
+
+    CommonHeaderMounted = render(
+      <CommonHeader isOpen handleOpenNav={() => {}} />
+    )
+  })
+
+  afterEach(() => {
+    CommonHeaderMounted.unmount()
+  })
+
+  it('should contain the correct header items', () => {
+    expect(screen.getByText('header.title')).toBeDefined()
+
+    render(<SearchBar />)
+    render(<UserMenu />)
+
+    const darkmodeToggle = screen.getByTestId('darkmode-toggle')
+    assert.ok(darkmodeToggle)
+
+    const languageToggle = screen.getByTestId('language-toggle')
+    assert.ok(languageToggle)
   })
 })

--- a/packages/lib/src/components/common/Header/CommonHeader.tsx
+++ b/packages/lib/src/components/common/Header/CommonHeader.tsx
@@ -55,6 +55,7 @@ export function CommonHeader({ isOpen, handleOpenNav }: CommonHeaderProps) {
         <Group noWrap>
           <Group noWrap>
             <ActionIcon
+              data-testid="darkmode-toggle"
               color="dark"
               sx={{
                 '&:hover': {
@@ -66,6 +67,7 @@ export function CommonHeader({ isOpen, handleOpenNav }: CommonHeaderProps) {
             </ActionIcon>
 
             <ActionIcon
+              data-testid="language-toggle"
               color="dark"
               sx={{
                 '&:hover': {

--- a/packages/lib/src/components/common/NavBar/CommonNavBar.test.tsx
+++ b/packages/lib/src/components/common/NavBar/CommonNavBar.test.tsx
@@ -1,18 +1,32 @@
-import { render } from '@testing-library/react'
-import { describe, it, vi } from 'vitest'
+import { render, RenderResult, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { CommonNavBar } from './CommonNavBar'
 
-vi.mock('react-i18next', () => {
-  return {
-    useTranslation: () => ({
-      t: (key: unknown) => key,
-    }),
-  }
-})
-
 describe('CommonNavBar', () => {
-  it('should render the navigation bar', () => {
-    render(<CommonNavBar isOpen />)
+  let CommonNavBarMounted: RenderResult
+
+  beforeEach(() => {
+    vi.mock('react-i18next', () => ({
+      useTranslation: () => {
+        return {
+          t: (str: unknown) => str,
+        }
+      },
+    }))
+
+    CommonNavBarMounted = render(<CommonNavBar isOpen />)
+  })
+
+  afterEach(() => {
+    CommonNavBarMounted.unmount()
+  })
+
+  it('should contain the correct navigation links', () => {
+    expect(screen.getByText('navigation.home')).toBeDefined()
+    expect(screen.getByText('navigation.users')).toBeDefined()
+    expect(screen.getByText('navigation.roles')).toBeDefined()
+    expect(screen.getByText('navigation.rights')).toBeDefined()
+    expect(screen.getByText('navigation.translations')).toBeDefined()
   })
 })


### PR DESCRIPTION
Closes #24 

Adds basic unit testing for the components consumed by the app shell.

Functionality like checking correct routing, etc. is not being tested yet as we don't have any routing implemented yet. But as we add features more test cases can be added accordingly.