### PR TITLE
refactor(docs): remove unnecessary why sections and fix typos

### DIFF
--- a/packages/docs/pages/devguide/new-component.mdx
+++ b/packages/docs/pages/devguide/new-component.mdx
@@ -14,9 +14,9 @@ The Header component does have other components it uses. Because they're specifi
 
 ## Details
 
-- component name is equal to the file name (both `PascalCase`)
+- The component name is equal to the file name (both `PascalCase`).
 
-- use functional components instead of class components
+- Use functional components instead of class components.
 
 ```tsx
 // ❌
@@ -31,7 +31,9 @@ function NewComponent(...) { ... }
 ...
 </details>
 
-- import types with `import type { ... } from ...` syntax
+---
+
+- Import types with `import type { ... } from ...` syntax.
 
 ```typescript
 // ❌
@@ -41,12 +43,10 @@ import { NewType } from ...
 import type { NewType } from ...
 ```
 
-<details>
-<summary>Why? 📝</summary>
-...
-</details>
+---
 
-- check size of imports (i.e. with VSCode plugin [import costs](https://marketplace.visualstudio.com/items?itemName=wix.vscode-import-cost)) and reduce where possible (green is fine, red should be reviewed)
+
+- Check size of imports (i.e. with VSCode plugin [import costs](https://marketplace.visualstudio.com/items?itemName=wix.vscode-import-cost)) and reduce where possible (green is fine, red should be reviewed)
 
 ![Import Cost Valid](/images/import-cost-green.png)
 
@@ -55,7 +55,9 @@ import type { NewType } from ...
 ...
 </details>
 
-- use function declaration syntax instead of arrow function syntax
+---
+
+- Use function declaration syntax instead of arrow function syntax.
 
 ```tsx
 // ❌
@@ -65,12 +67,10 @@ const NewComponent = (...) => { ... }
 function NewComponent(...) { ... }
 ```
 
-<details>
-<summary>Why? 📝</summary>
-...
-</details>
 
-- export the functional component as named export (`export function MyComponent(...)`)
+---
+
+- Export the functional component as named export (`export function MyComponent(...)`).
 
 ```tsx
 // ❌
@@ -86,7 +86,9 @@ export function NewComponent(...) { ... }
 Exporting functions, variables and types via the named export syntax has the advantage of automatic bulk-renaming if needed.
 </details>
 
-- type the component's props with a TypeScript `type` and destructure them where possible
+---
+
+- Type the component's props with a TypeScript `type` and destructure them where possible.
 
 ```tsx
 // ❌
@@ -109,7 +111,9 @@ function NewComponent({ username, age }: NewComponentProps) { ... }
 ...
 </details>
 
-- specify return type of component
+---
+
+- Specify the return type of a component.
 
 ```tsx
 // ❌
@@ -126,14 +130,17 @@ By specifying the concret return type, TypeScript will give you an error if you 
 Additionally, it increases the consistency of always specifying the return type of functions throughout the codebase and provides a better readability if you can directly recognize what a function returns.
 </details>
 
-- declare types in a separate file on the same level as the component inside a `types.ts` file
+---
+
+- Declare types in a separate file on the same level as the component inside a `types.ts` file.
 
 <details>
 <summary>Why? 📝</summary>
 ...
 </details>
 
-- logic that belongs together should live as close together as possible and they should be separated through a blank line
+---
+- Logic that belongs together should live as close together as possible and they should be separated through a blank line.
 
 ```tsx
 // ❌
@@ -161,7 +168,9 @@ function NewComponent(...): JSX.Element {
 }
 ```
 
-- separate JSX elements with a blank line if they have the same indentation
+---
+
+- Separate JSX elements with a blank line if they have the same indentation.
 
 ```tsx
 // ❌
@@ -194,19 +203,19 @@ function NewComponent(...): JSX.Element {
 }
 ```
 
-<details>
-<summary>Why? 📝</summary>
-...
-</details>
 
-- lazy load components if it makes sense
+---
+
+- Lazy load components if it makes sense.
 
 <details>
 <summary>Why? 📝</summary>
 ...
 </details>
 
-- all texts are replaced with a corresponding `i18n` variable
+---
+
+- All texts are replaced with a corresponding `i18n` variable.
 
 ```tsx
 // ❌
@@ -221,7 +230,9 @@ function NewComponent(...): JSX.Element {
 ...
 </details>
 
-- no TypeScript `any`
+---
+
+- Do not use TypeScript `any`.
 
 ```tsx
 // ❌
@@ -254,32 +265,40 @@ By telling TypeScript that a variable or function is of type `any` you disable T
 Some typing is hard, we all know that, but at least ask for help and don't go the simple and insecure way.
 </details>
 
-- treat server requests as sensible
+---
+
+- Treat server requests as sensible.
 
 <details>
 <summary>Why?</summary>
 Double-check if you make unnecessary or too many server requests caused by a suboptimal implementation. It could led to a bad performance and UX.
 </details>
 
-- provide feedback for every write, delete, update operation
+---
+
+- Provide feedback for every write, delete, update operation.
 
 <details>
 <summary>Why?</summary>
 A good UX consists of proper user feedback i.e. notifications. That gives the user confidence that his action was successful or has failed.
 </details>
 
-- proper code formatting via Prettier & linting via ESLint
+---
+
+- Use proper code formatting via Prettier & linting via ESLint.
 
 <details>
 <summary>Why?</summary>
 Tools like Prettier (semantic) and ESLint (syntax) ensure a consistent codebase and keep readability on a high level.
 </details>
 
-- check console (browser and terminal) for any errors or warnings
+---
+
+- Check console (browser and terminal) for any errors or warnings.
 
 <details>
 <summary>Why?</summary>
-Even though your implementation is fine, warning or even error can occur. Sometimes they're not reflected in the UI but in the console.
+Even though your implementation is fine, a warning or even an error can occur. Sometimes they're not reflected in the UI but in the console.
 </details>
 
 


### PR DESCRIPTION
**DESCRIPTION**
I removed some unnecessary Why-Sections, fixed some typos and added horizontal lines to improve the readability.

**CLOSES**
closes #71 

**COMMITS**
[refactor(docs): remove unnecessary why sections and fix typos](https://github.com/Frachtwerk/essencium-frontend/commit/b66c8f97a7f3420e68e4abe783f0513a4c5a2ca0)