### PR TITLE
refactor(docs): remove commit section

### DIFF
--- a/packages/docs/pages/devguide/pull-requests.mdx
+++ b/packages/docs/pages/devguide/pull-requests.mdx
@@ -12,10 +12,6 @@ _loom link if applicable_
 **CLOSES**
 
 _list of issues closed in this PR_
-
-**COMMITS**
-
-_list of commits made in this PR_
 ```
 
 The person who worked on the pull request should always set the appropriate labels and corresponding milestone, as well as marking themselves as assignee.


### PR DESCRIPTION
**DESCRIPTION**
I think we don't need the commits section inside the template because they can be read out inside the PR. I find it's unnecessary extra work.

![image](https://user-images.githubusercontent.com/54100938/217596006-2153de71-12b8-416d-9302-1a0697eebf01.png)
