### PR TITLE
refactor(lib): remove testdata-id & refactor to find & test routerlinks

### DIFF
--- a/packages/lib/src/components/Footer/Footer.test.tsx
+++ b/packages/lib/src/components/Footer/Footer.test.tsx
@@ -1,4 +1,5 @@
 import { render, RenderResult, screen } from '@testing-library/react'
+import { CSSProperties } from 'react'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { Footer } from './Footer'
@@ -10,21 +11,33 @@ describe('Footer', () => {
   const FOOTER_LINKS: FooterLink[] = [
     {
       label: 'footer.privacy',
-      to: '/',
+      to: 'privacy',
     },
     {
       label: 'footer.imprint',
-      to: '/',
+      to: 'imprint',
     },
     {
       label: 'footer.contact',
-      to: '/contact',
+      to: 'contact',
     },
   ]
 
   beforeAll(() => {
     vi.mock('@tanstack/react-router', () => ({
-      Link: ({ children }: { children: React.ReactNode }) => children,
+      Link: ({
+        children,
+        to,
+        ...props
+      }: {
+        children: React.ReactNode
+        to: string
+        style: CSSProperties
+      }) => (
+        <a {...props} href={to}>
+          {children}
+        </a>
+      ),
     }))
 
     vi.mock('react-i18next', () => ({
@@ -43,9 +56,24 @@ describe('Footer', () => {
   })
 
   it('should contain the correct content', () => {
-    expect(screen.getAllByText('footer.license')).toBeDefined()
-    expect(screen.getAllByText('footer.privacy')).toBeDefined()
-    expect(screen.getAllByText('footer.imprint')).toBeDefined()
-    expect(screen.getAllByText('footer.contact')).toBeDefined()
+    expect(screen.getByText('footer.license').closest('a')).toHaveProperty(
+      'href',
+      'license'
+    )
+
+    expect(screen.getByText('footer.privacy').closest('a')).toHaveProperty(
+      'href',
+      'privacy'
+    )
+
+    expect(screen.getByText('footer.imprint').closest('a')).toHaveProperty(
+      'href',
+      'imprint'
+    )
+
+    expect(screen.getByText('footer.contact').closest('a')).toHaveProperty(
+      'href',
+      'contact'
+    )
   })
 })

--- a/packages/lib/src/components/Footer/Footer.tsx
+++ b/packages/lib/src/components/Footer/Footer.tsx
@@ -27,7 +27,12 @@ export function Footer({ links }: FooterLinksProps): JSX.Element {
           <Flex gap="xs" align="center" ml="xs">
             <IconCopyright size="16" />
 
-            <Text>{t('footer.license')}</Text>
+            <RouterLink
+              to="license"
+              style={{ textDecoration: 'none', color: theme.colors.blue[8] }}
+            >
+              <Text> {t('footer.license')} </Text>
+            </RouterLink>
           </Flex>
         </MediaQuery>
 

--- a/packages/lib/src/components/Header/Header.test.tsx
+++ b/packages/lib/src/components/Header/Header.test.tsx
@@ -43,17 +43,21 @@ describe('Header', () => {
     render(<SearchBar />)
     render(<UserMenu />)
 
-    const darkmodeToggle = screen.getByTestId('darkmode-toggle')
+    const darkmodeToggle = screen.getByRole('button', {
+      name: 'darkmode-toggle',
+    })
     assert.ok(darkmodeToggle)
 
-    const languageToggle = screen.getByTestId('language-toggle')
+    const languageToggle = screen.getByRole('button', {
+      name: 'language-toggle',
+    })
     assert.ok(languageToggle)
   })
 
   it('should display the correct language', () => {
     const { i18n } = useTranslation()
 
-    expect(screen.getByTestId('selected-language').textContent).toBe(
+    expect(screen.getByLabelText('selected-language').textContent).toBe(
       i18n.language.toUpperCase()
     )
   })

--- a/packages/lib/src/components/Header/Header.tsx
+++ b/packages/lib/src/components/Header/Header.tsx
@@ -74,7 +74,7 @@ export function Header({ isOpen, handleOpenNav }: HeaderProps): JSX.Element {
             <HoverCard>
               <HoverCard.Target>
                 <ActionIcon
-                  data-testid="darkmode-toggle"
+                  aria-label="darkmode-toggle"
                   onClick={() => toggleColorScheme()}
                   color="dark"
                   sx={{
@@ -102,7 +102,7 @@ export function Header({ isOpen, handleOpenNav }: HeaderProps): JSX.Element {
             <HoverCard>
               <HoverCard.Target>
                 <ActionIcon
-                  data-testid="language-toggle"
+                  aria-label="language-toggle"
                   color="dark"
                   onClick={() => {
                     onToggleLanguage()
@@ -116,7 +116,7 @@ export function Header({ isOpen, handleOpenNav }: HeaderProps): JSX.Element {
                     },
                   }}
                 >
-                  <Text data-testid="selected-language" size="lg">
+                  <Text aria-label="selected-language" size="lg">
                     {i18n.language.toUpperCase()}
                   </Text>
                 </ActionIcon>

--- a/packages/lib/src/components/Home/Home.test.tsx
+++ b/packages/lib/src/components/Home/Home.test.tsx
@@ -1,4 +1,5 @@
 import { render, RenderResult, screen } from '@testing-library/react'
+import { CSSProperties } from 'react'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { Home } from './Home'
@@ -8,7 +9,19 @@ describe('Home', () => {
 
   beforeAll(() => {
     vi.mock('@tanstack/react-router', () => ({
-      Link: ({ children }: { children: React.ReactNode }) => children,
+      Link: ({
+        children,
+        to,
+        ...props
+      }: {
+        children: React.ReactNode
+        to: string
+        style: CSSProperties
+      }) => (
+        <a {...props} href={to}>
+          {children}
+        </a>
+      ),
     }))
 
     vi.mock('react-i18next', () => ({
@@ -27,7 +40,13 @@ describe('Home', () => {
 
   it('should render the correct actions', () => {
     expect(screen.getByText('homeView.action.search')).toBeDefined()
-    expect(screen.getByText('homeView.action.users')).toBeDefined()
-    expect(screen.getByText('homeView.action.profile')).toBeDefined()
+
+    expect(
+      screen.getByText('homeView.action.users').closest('a')
+    ).toHaveProperty('href', 'users')
+
+    expect(
+      screen.getByText('homeView.action.profile').closest('a')
+    ).toHaveProperty('href', 'profile')
   })
 })

--- a/packages/lib/src/components/NavBar/NavBar.test.tsx
+++ b/packages/lib/src/components/NavBar/NavBar.test.tsx
@@ -6,6 +6,7 @@ import {
   IconUsers,
 } from '@tabler/icons'
 import { render, RenderResult, screen } from '@testing-library/react'
+import { CSSProperties } from 'react'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { NavLink } from './components'
@@ -49,7 +50,19 @@ describe('NavBar', () => {
 
   beforeAll(() => {
     vi.mock('@tanstack/react-router', () => ({
-      Link: ({ children }: { children: React.ReactNode }) => children,
+      Link: ({
+        children,
+        to,
+        ...props
+      }: {
+        children: React.ReactNode
+        to: string
+        style: CSSProperties
+      }) => (
+        <a {...props} href={to}>
+          {children}
+        </a>
+      ),
     }))
 
     vi.mock('react-i18next', () => ({
@@ -68,10 +81,24 @@ describe('NavBar', () => {
   })
 
   it('should contain the correct navigation links', () => {
-    expect(screen.getByText('navigation.home')).toBeDefined()
-    expect(screen.getByText('navigation.users')).toBeDefined()
-    expect(screen.getByText('navigation.roles')).toBeDefined()
-    expect(screen.getByText('navigation.rights')).toBeDefined()
-    expect(screen.getByText('navigation.translations')).toBeDefined()
+    expect(screen.getByText('navigation.home').closest('a')).toHaveProperty(
+      'href',
+      '/home'
+    )
+    expect(screen.getByText('navigation.users').closest('a')).toHaveProperty(
+      'href',
+      '/users'
+    )
+    expect(screen.getByText('navigation.roles').closest('a')).toHaveProperty(
+      'href',
+      '/roles'
+    )
+    expect(screen.getByText('navigation.rights').closest('a')).toHaveProperty(
+      'href',
+      '/rights'
+    )
+    expect(
+      screen.getByText('navigation.translations').closest('a')
+    ).toHaveProperty('href', '/translations')
   })
 })


### PR DESCRIPTION
**DESCRIPTION**
- Data-testid has been removed from tests 
- Tests have been refactored to find and test links embedded via tanstack router

**CLOSES**
#95 

**COMMITS**
[refactor(lib): remove testdata-id & refactor to find & test routerlinks](https://github.com/Frachtwerk/essencium-frontend/commit/8aad32029a56a5bbca095fc7c8b9f66035ae05a6)