### PR TITLE
refactor: remove link in footer component and test

### DIFF
--- a/packages/lib/src/components/Footer/Footer.test.tsx
+++ b/packages/lib/src/components/Footer/Footer.test.tsx
@@ -56,11 +56,6 @@ describe('Footer', () => {
   })
 
   it('should contain the correct content', () => {
-    expect(screen.getByText('footer.license').closest('a')).toHaveProperty(
-      'href',
-      'license'
-    )
-
     expect(screen.getByText('footer.privacy').closest('a')).toHaveProperty(
       'href',
       'privacy'

--- a/packages/lib/src/components/Footer/Footer.tsx
+++ b/packages/lib/src/components/Footer/Footer.tsx
@@ -27,12 +27,7 @@ export function Footer({ links }: FooterLinksProps): JSX.Element {
           <Flex gap="xs" align="center" ml="xs">
             <IconCopyright size="16" />
 
-            <RouterLink
-              to="license"
-              style={{ textDecoration: 'none', color: theme.colors.blue[8] }}
-            >
-              <Text> {t('footer.license')} </Text>
-            </RouterLink>
+            <Text> {t('footer.license')} </Text>
           </Flex>
         </MediaQuery>
 


### PR DESCRIPTION
**DESCRIPTION**
The link has been removed from the license info and the test has been adjusted. 

**CLOSES**
#115 

**COMMITS**
[refactor: remove link in footer component and test](https://github.com/Frachtwerk/essencium-frontend/commit/69dd4658955173c89e877b39181b357ee37cbe6c)

