### PR TITLE
test: use resolved strings in test env instead of key

### DIFF
--- a/packages/lib/src/components/Footer/Footer.test.tsx
+++ b/packages/lib/src/components/Footer/Footer.test.tsx
@@ -1,5 +1,7 @@
 import { render, RenderResult, screen } from '@testing-library/react'
 import { CSSProperties } from 'react'
+import { initReactI18next } from 'react-i18next'
+import { initI18n } from 'translations'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { Footer } from './Footer'
@@ -40,13 +42,7 @@ describe('Footer', () => {
       ),
     }))
 
-    vi.mock('react-i18next', () => ({
-      useTranslation: () => {
-        return {
-          t: (str: unknown) => str,
-        }
-      },
-    }))
+    initI18n(initReactI18next)
 
     FooterMounted = render(<Footer links={FOOTER_LINKS} />)
   })
@@ -56,17 +52,17 @@ describe('Footer', () => {
   })
 
   it('should contain the correct content', () => {
-    expect(screen.getByText('footer.privacy').closest('a')).toHaveProperty(
+    expect(screen.getByText('Privacy').closest('a')).toHaveProperty(
       'href',
       'privacy'
     )
 
-    expect(screen.getByText('footer.imprint').closest('a')).toHaveProperty(
+    expect(screen.getByText('Imprint').closest('a')).toHaveProperty(
       'href',
       'imprint'
     )
 
-    expect(screen.getByText('footer.contact').closest('a')).toHaveProperty(
+    expect(screen.getByText('Contact').closest('a')).toHaveProperty(
       'href',
       'contact'
     )

--- a/packages/lib/src/components/Header/Header.test.tsx
+++ b/packages/lib/src/components/Header/Header.test.tsx
@@ -1,6 +1,7 @@
 import * as mantine from '@mantine/core'
 import { render, RenderResult, screen } from '@testing-library/react'
-import { useTranslation } from 'react-i18next'
+import { initReactI18next } from 'react-i18next'
+import { i18n, initI18n } from 'translations'
 import { afterAll, assert, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { SearchBar, UserMenu } from './components'
@@ -10,17 +11,6 @@ describe('Header', () => {
   let HeaderMounted: RenderResult
 
   beforeAll(() => {
-    vi.mock('react-i18next', () => ({
-      useTranslation: () => {
-        return {
-          t: (str: unknown) => str,
-          i18n: {
-            language: 'en',
-          },
-        }
-      },
-    }))
-
     vi.mock('@tanstack/react-router', () => ({
       Link: ({ children }: { children: React.ReactNode }) => children,
     }))
@@ -30,6 +20,8 @@ describe('Header', () => {
       toggleColorScheme: () => {},
     }))
 
+    initI18n(initReactI18next)
+
     HeaderMounted = render(<Header isOpen handleOpenNav={() => {}} />)
   })
 
@@ -38,7 +30,7 @@ describe('Header', () => {
   })
 
   it('should contain the correct header items', () => {
-    expect(screen.getByText('header.title')).toBeDefined()
+    expect(screen.getByText('Essencium')).toBeDefined()
 
     render(<SearchBar />)
     render(<UserMenu />)
@@ -55,8 +47,6 @@ describe('Header', () => {
   })
 
   it('should display the correct language', () => {
-    const { i18n } = useTranslation()
-
     expect(screen.getByLabelText('selected-language').textContent).toBe(
       i18n.language.toUpperCase()
     )

--- a/packages/lib/src/components/NavBar/NavBar.test.tsx
+++ b/packages/lib/src/components/NavBar/NavBar.test.tsx
@@ -7,6 +7,8 @@ import {
 } from '@tabler/icons'
 import { render, RenderResult, screen } from '@testing-library/react'
 import { CSSProperties } from 'react'
+import { initReactI18next } from 'react-i18next'
+import { initI18n } from 'translations'
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { NavLink } from './components'
@@ -65,13 +67,7 @@ describe('NavBar', () => {
       ),
     }))
 
-    vi.mock('react-i18next', () => ({
-      useTranslation: () => {
-        return {
-          t: (str: unknown) => str,
-        }
-      },
-    }))
+    initI18n(initReactI18next)
 
     NavBarMounted = render(<NavBar isOpen links={NAV_LINKS} />)
   })
@@ -81,24 +77,25 @@ describe('NavBar', () => {
   })
 
   it('should contain the correct navigation links', () => {
-    expect(screen.getByText('navigation.home').closest('a')).toHaveProperty(
+    expect(screen.getByText('Home').closest('a')).toHaveProperty(
       'href',
       '/home'
     )
-    expect(screen.getByText('navigation.users').closest('a')).toHaveProperty(
+    expect(screen.getByText('Users').closest('a')).toHaveProperty(
       'href',
       '/users'
     )
-    expect(screen.getByText('navigation.roles').closest('a')).toHaveProperty(
+    expect(screen.getByText('Roles').closest('a')).toHaveProperty(
       'href',
       '/roles'
     )
-    expect(screen.getByText('navigation.rights').closest('a')).toHaveProperty(
+    expect(screen.getByText('Rights').closest('a')).toHaveProperty(
       'href',
       '/rights'
     )
-    expect(
-      screen.getByText('navigation.translations').closest('a')
-    ).toHaveProperty('href', '/translations')
+    expect(screen.getByText('Translations').closest('a')).toHaveProperty(
+      'href',
+      '/translations'
+    )
   })
 })


### PR DESCRIPTION
**DESCRIPTION**
I found a solution to use the i18n instance in our tests. Interesting for @luisstd & @PhilKsr as well maybe :-)

**CLOSES**
Closes #105 