### PR TITLE
fix: fix default language overriding language detector

### DIFF
--- a/packages/translations/src/initI18n.ts
+++ b/packages/translations/src/initI18n.ts
@@ -20,7 +20,6 @@ function initI18n(reacti18n: ThirdPartyModule): void {
     // init i18next
     // for all options read: https://www.i18next.com/overview/configuration-options
     .init({
-      lng: DEFAULT_LANGUAGE,
       resources: {
         en: {
           translation: en,


### PR DESCRIPTION
**DESCRIPTION**
- Fixes the language selection not being persisted on reload
- `DEFAULT_LANGUAGE` is now only used as fallback
