### PR TITLE
fix: display error messages of form inputs in add role modal

### DIFF
--- a/packages/lib/src/components/AddRole/AddRole.tsx
+++ b/packages/lib/src/components/AddRole/AddRole.tsx
@@ -101,7 +101,7 @@ function AddRole({
           />
 
           {formState.errors.name && (
-            <Text mt={4} ml={5} fz="xs" color="red">
+            <Text ml={5} fz="xs" color="red">
               {formState.errors.name?.message}
             </Text>
           )}
@@ -126,7 +126,7 @@ function AddRole({
           />
 
           {formState.errors.description && (
-            <Text mt={4} ml={5} fz="xs" color="red">
+            <Text ml={5} fz="xs" color="red">
               {formState.errors.description?.message}
             </Text>
           )}

--- a/packages/translations/src/languages/de.json
+++ b/packages/translations/src/languages/de.json
@@ -277,6 +277,12 @@
     },
     "role": {
       "isRequired": "Bitte wählen Sie eine Rolle"
+    },
+    "roleDescription": {
+      "minLength": "Rollenbeschreibung muss mindestens 8 Zeichen lang sein."
+    },
+    "roleName": {
+      "minLength": "Rollenname muss mindestens 2 Zeichen lang sein."
     }
   },
   "notifications": {

--- a/packages/translations/src/languages/en.json
+++ b/packages/translations/src/languages/en.json
@@ -277,6 +277,12 @@
     },
     "role": {
       "isRequired": "Please select a role"
+    },
+    "roleDescription": {
+      "minLength": "Role description must be at least 8 characters long."
+    },
+    "roleName": {
+      "minLength": "Role name must be at least 2 characters long."
     }
   },
   "notifications": {

--- a/packages/types/src/role.ts
+++ b/packages/types/src/role.ts
@@ -1,12 +1,17 @@
+import { i18n } from 'translations'
 import { z } from 'zod'
 
 import { basePropertiesSchema } from './base'
 import { rightOutputSchema } from './right'
 
+const { t } = i18n
+
 const sharedPropertiesSchema = z.object({
-  description: z.string(),
+  description: z
+    .string()
+    .min(8, String(t('validation.roleDescription.minLength'))),
   editable: z.boolean(),
-  name: z.string(),
+  name: z.string().min(2, String(t('validation.roleName.minLength'))),
   protected: z.boolean(),
 })
 


### PR DESCRIPTION
**DESCRIPTION**
The corresponding error messages are now displayed below the affected form input in the add role modal. 


**CLOSES**
closes #260 