### PR TITLE
fix: add box container for error messages and adjust margins

### DIFF
--- a/packages/lib/src/components/AddRole/AddRole.tsx
+++ b/packages/lib/src/components/AddRole/AddRole.tsx
@@ -100,11 +100,13 @@ function AddRole({
             )}
           />
 
-          {formState.errors.name && (
-            <Text ml={5} fz="xs" color="red">
-              {formState.errors.name?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.name && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.name?.message}
+              </Text>
+            )}
+          </Box>
 
           <Controller
             name="description"
@@ -125,11 +127,13 @@ function AddRole({
             )}
           />
 
-          {formState.errors.description && (
-            <Text ml={5} fz="xs" color="red">
-              {formState.errors.description?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.description && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.description?.message}
+              </Text>
+            )}
+          </Box>
 
           <Divider
             my="xs"

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Flex,
   MediaQuery,
@@ -62,11 +63,13 @@ export function PasswordChangeForm({
               )}
             />
 
-            {formState.errors.verification && (
-              <Text fz="xs" color="red">
-                {formState.errors.verification?.message}
-              </Text>
-            )}
+            <Box mt="-0.6rem" h="0.8rem">
+              {formState.errors.verification && (
+                <Text ml={5} fz="xs" color="red">
+                  {formState.errors.verification?.message}
+                </Text>
+              )}
+            </Box>
           </Stack>
         </MediaQuery>
 
@@ -92,11 +95,13 @@ export function PasswordChangeForm({
               )}
             />
 
-            {formState.errors.password && (
-              <Text fz="xs" color="red">
-                {formState.errors.password?.message}
-              </Text>
-            )}
+            <Box mt="-0.6rem" h="0.8rem">
+              {formState.errors.password && (
+                <Text ml={5} fz="xs" color="red">
+                  {formState.errors.password?.message}
+                </Text>
+              )}
+            </Box>
           </Stack>
         </MediaQuery>
 
@@ -122,11 +127,13 @@ export function PasswordChangeForm({
               )}
             />
 
-            {formState.errors.confirmPassword && (
-              <Text fz="xs" color="red">
-                {formState.errors.confirmPassword?.message}
-              </Text>
-            )}
+            <Box mt="-0.6rem" h="0.8rem">
+              {formState.errors.confirmPassword && (
+                <Text ml={5} fz="xs" color="red">
+                  {formState.errors.confirmPassword?.message}
+                </Text>
+              )}
+            </Box>
           </Stack>
         </MediaQuery>
 

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.tsx
@@ -1,4 +1,12 @@
-import { Button, Flex, Select, Stack, Text, TextInput } from '@mantine/core'
+import {
+  Box,
+  Button,
+  Flex,
+  Select,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core'
 import { Controller } from 'react-hook-form'
 import { i18n } from 'translations'
 import { UserOutput, UserUpdate, userUpdateSchema } from 'types'
@@ -26,10 +34,10 @@ export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
     <form onSubmit={handleSubmit(onSubmit)}>
       <Flex
         direction={{ base: 'column', sm: 'row' }}
-        gap={{ base: 'sm', sm: 'lg' }}
+        gap={{ base: 'xs', sm: 'md' }}
         justify={{ sm: 'space-between' }}
       >
-        <Stack miw="45%" mb="md">
+        <Stack miw="45%">
           <Controller
             name="firstName"
             control={control}
@@ -49,14 +57,16 @@ export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
             )}
           />
 
-          {formState.errors.firstName && (
-            <Text fz="xs" color="red">
-              {formState.errors.firstName?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.firstName && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.firstName?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
 
-        <Stack mb="md" miw="45%">
+        <Stack miw="45%">
           <Controller
             name="lastName"
             control={control}
@@ -76,20 +86,23 @@ export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
             )}
           />
 
-          {formState.errors.lastName && (
-            <Text mt={4} ml={5} fz="xs" color="red">
-              {formState.errors.lastName?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.lastName && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.lastName?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
       </Flex>
 
       <Flex
         direction={{ base: 'column', sm: 'row' }}
-        gap={{ base: 'sm', sm: 'lg' }}
+        gap={{ base: 'sm', sm: 'md' }}
         justify={{ sm: 'space-between' }}
+        mt="xs"
       >
-        <Stack mb="md" miw="45%">
+        <Stack miw="45%">
           <Controller
             name="phone"
             control={control}
@@ -109,14 +122,16 @@ export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
             )}
           />
 
-          {formState.errors.phone && (
-            <Text mt={4} ml={5} fz="xs" color="red">
-              {formState.errors.phone?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.phone && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.phone?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
 
-        <Stack mb="md" miw="45%">
+        <Stack miw="45%">
           <Controller
             name="mobile"
             control={control}
@@ -136,20 +151,23 @@ export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
             )}
           />
 
-          {formState.errors.mobile && (
-            <Text mt={4} ml={5} fz="xs" color="red">
-              {formState.errors.mobile?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.mobile && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.mobile?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
       </Flex>
 
       <Flex
         direction={{ base: 'column', sm: 'row' }}
-        gap={{ base: 'sm', sm: 'lg' }}
+        gap={{ base: 'sm', sm: 'md' }}
         justify={{ sm: 'space-between' }}
+        mt="xs"
       >
-        <Stack mb="md" miw="45%">
+        <Stack miw="45%">
           <Controller
             name="email"
             control={control}
@@ -170,14 +188,16 @@ export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
             )}
           />
 
-          {formState.errors.email && (
-            <Text mt={4} ml={5} fz="xs" color="red">
-              {formState.errors.email?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.email && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.email?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
 
-        <Stack mb="md" miw="45%">
+        <Stack miw="45%">
           <Controller
             name="locale"
             control={control}
@@ -199,11 +219,13 @@ export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
             )}
           />
 
-          {formState.errors.locale && (
-            <Text mt={4} ml={5} fz="xs" color="red">
-              {formState.errors.locale?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.locale && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.locale?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
       </Flex>
 

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/ProfileSettingsForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/ProfileSettingsForm.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Flex,
   MediaQuery,
@@ -97,11 +98,13 @@ export function ProfileSettingsForm({
           />
         </MediaQuery>
 
-        {formState.errors.role && (
-          <Text fz="xs" color="red">
-            {formState.errors.role?.message}
-          </Text>
-        )}
+        <Box mt="-0.6rem" h="0.8rem">
+          {formState.errors.role && (
+            <Text ml={5} fz="xs" color="red">
+              {formState.errors.role?.message}
+            </Text>
+          )}
+        </Box>
       </Flex>
 
       <Button type="submit" mt="md" variant="light">

--- a/packages/lib/src/components/User/UserForm.tsx
+++ b/packages/lib/src/components/User/UserForm.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Button,
   Flex,
   PasswordInput,
@@ -45,10 +46,10 @@ export function UserForm({
 
       <Flex
         direction={{ base: 'column', sm: 'row' }}
-        gap={{ base: 'sm', sm: 'lg' }}
+        gap={{ base: 'sm', sm: 'md' }}
         justify={{ sm: 'space-between' }}
       >
-        <Stack miw="45%" mb="md" spacing="xs">
+        <Stack miw="45%">
           <Controller
             name="firstName"
             control={control}
@@ -65,14 +66,16 @@ export function UserForm({
             )}
           />
 
-          {formState.errors.firstName && (
-            <Text fz="xs" color="red">
-              {formState.errors.firstName?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.firstName && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.firstName?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
 
-        <Stack miw="45%" mb="md" spacing="xs">
+        <Stack miw="45%">
           <Controller
             name="lastName"
             control={control}
@@ -89,20 +92,23 @@ export function UserForm({
             )}
           />
 
-          {formState.errors.lastName && (
-            <Text mt={4} ml={5} fz="xs" color="red">
-              {formState.errors.lastName?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.lastName && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.lastName?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
       </Flex>
 
       <Flex
         direction={{ base: 'column', sm: 'row' }}
-        gap={{ base: 'sm', sm: 'lg' }}
+        gap={{ base: 'sm', sm: 'md' }}
         justify={{ sm: 'space-between' }}
+        mt="xs"
       >
-        <Stack miw="45%" mb="md" spacing="xs">
+        <Stack miw="45%">
           <Controller
             name="email"
             control={control}
@@ -119,14 +125,16 @@ export function UserForm({
             )}
           />
 
-          {formState.errors.email && (
-            <Text mt={4} ml={5} fz="xs" color="red">
-              {formState.errors.email?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.email && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.email?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
 
-        <Stack miw="45%" mb="md" spacing="xs">
+        <Stack miw="45%">
           <Controller
             name="password"
             control={control}
@@ -142,20 +150,23 @@ export function UserForm({
             )}
           />
 
-          {formState.errors.password && (
-            <Text fz="xs" color="red">
-              {formState.errors.password?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.password && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.password?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
       </Flex>
 
       <Flex
         direction={{ base: 'column', sm: 'row' }}
-        gap={{ base: 'sm', sm: 'lg' }}
+        gap={{ base: 'sm', sm: 'md' }}
         justify={{ sm: 'space-between' }}
+        mt="xs"
       >
-        <Stack mb="md" miw="45%" spacing="xs">
+        <Stack miw="45%">
           <Controller
             name="phone"
             control={control}
@@ -171,14 +182,16 @@ export function UserForm({
             )}
           />
 
-          {formState.errors.phone && (
-            <Text fz="xs" color="red">
-              {formState.errors.phone?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.phone && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.phone?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
 
-        <Stack miw="45%" mb="md" spacing="xs">
+        <Stack miw="45%">
           <Controller
             name="mobile"
             control={control}
@@ -194,11 +207,13 @@ export function UserForm({
             )}
           />
 
-          {formState.errors.mobile && (
-            <Text fz="xs" color="red">
-              {formState.errors.mobile?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.mobile && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.mobile?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
       </Flex>
 
@@ -224,11 +239,11 @@ export function UserForm({
 
       <Flex
         direction={{ base: 'column', sm: 'row' }}
-        gap={{ base: 'sm', sm: 'lg' }}
+        gap={{ base: 'sm', sm: 'md' }}
         justify={{ sm: 'space-between' }}
-        mt="lg"
+        mt="sm"
       >
-        <Stack miw="45%" mb="md" spacing="xs">
+        <Stack miw="45%">
           <Controller
             name="locale"
             control={control}
@@ -247,14 +262,16 @@ export function UserForm({
             )}
           />
 
-          {formState.errors.locale && (
-            <Text fz="xs" color="red">
-              {formState.errors.locale?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.locale && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.locale?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
 
-        <Stack miw="45%" mb="md" spacing="xs">
+        <Stack miw="45%">
           <Controller
             name="role"
             control={control}
@@ -275,11 +292,13 @@ export function UserForm({
             )}
           />
 
-          {formState.errors.role && (
-            <Text fz="xs" color="red">
-              {formState.errors.role?.message}
-            </Text>
-          )}
+          <Box mt="-0.6rem" h="0.8rem">
+            {formState.errors.role && (
+              <Text ml={5} fz="xs" color="red">
+                {formState.errors.role?.message}
+              </Text>
+            )}
+          </Box>
         </Stack>
       </Flex>
 


### PR DESCRIPTION
**DESCRIPTION**
A box element has been added as a container for the error messages of input fields in `Add-User-View`, `Profile-View` and `Add-Role-View`. The error messages now no longer move the input fields.

**CLOSES**
closes #257 