### PR TITLE
ci: add Trivy repo scan job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,29 @@ jobs:
   #       packages/app/test-results
   #       packages/app/playwright-report
 
+  security:
+    name: Vulnerability Scan
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'fs'
+          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL'
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: 'trivy-results.sarif'
+
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -183,7 +206,7 @@ jobs:
     name: Release
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    needs: [lint, unit-tests, build] # [lint, unit-tests, e2e-tests, build]
+    needs: [lint, unit-tests, build, security] # [lint, unit-tests, e2e-tests, build]
     steps:
       - name: Release Please
         uses: google-github-actions/release-please-action@v3


### PR DESCRIPTION
**DESCRIPTION**
 
Add Trivy repo scan job in pipeline to achieve more security and receive relevant information about vulnerabilities.
 
**CLOSES**
 
Closes #373 