### PR TITLE
Prevent line break when collapsing nav bar

### DIFF
--- a/packages/lib/src/components/NavBar/components/NavLinks.tsx
+++ b/packages/lib/src/components/NavBar/components/NavLinks.tsx
@@ -67,6 +67,7 @@ export function NavLinks({ links, user }: Props): JSX.Element {
                 },
                 label: {
                   fontSize: theme.fontSizes.sm,
+                  whiteSpace: 'nowrap',
                 },
               }}
             />


### PR DESCRIPTION
**DESCRIPTION:**
When collapsing the sidebar, longer labels will not wrap anymore. 

**CLOSES:**
#375 