### PR TITLE
fix: accept UUIDs for id beside number

### DIFF
--- a/packages/types/src/base.ts
+++ b/packages/types/src/base.ts
@@ -22,7 +22,9 @@ import { z } from 'zod'
 // we use 'nullish' here because this is the datatype that comes from the backend.
 // we transform it to 'undefined' because react-form-hooks only works with 'undefined'
 export const basePropertiesSchema = z.object({
-  id: z.number().transform(value => (value === null ? undefined : value)),
+  id: z
+    .union([z.string().uuid(), z.number()])
+    .transform(value => (value === null ? undefined : value)),
   createdAt: z.string().nullish(),
   createdBy: z.string().nullish(),
   updatedAt: z.string().nullish(),


### PR DESCRIPTION
**DESCRIPTION**
 
In a customer project, I came across the issue, that Essencium only supports `number` for `id`s instead of `number` and `string` (`UUID` to be precise). I widened the the `basePropertiesSchema` for `id` to also accept `UUID`s.
 
**CLOSES**
 
Closes #397 