### PR TITLE
fix: set page number to zero when fetching roles

### DIFF
--- a/packages/app/src/pages/rights/index.tsx
+++ b/packages/app/src/pages/rights/index.tsx
@@ -84,7 +84,7 @@ function RightsView(): JSX.Element {
   })
 
   const { data: roles, refetch: refetchRoles } = useGetRoles({
-    page: activePage - 1,
+    page: 0,
     size: 9999,
     sort: 'name,asc',
   })


### PR DESCRIPTION
**DESCRIPTION:**

The roles were fetched based on the page number and because of that there were no roles to display on page two and onwards. The page number has been set to zero now to get all roles.  

Closes #361 