### PR TITLE
refactor: remove Renovate in favour of Dependabot

### DIFF
--- a/packages/docs/pages/architecture.mdx
+++ b/packages/docs/pages/architecture.mdx
@@ -46,6 +46,5 @@ That gives us the following architecture:
 ├── pnpm-workspace.yaml
 ├── README.md
 ├── release-please-config.json
-├── renovate.json
 └── tsconfig.json
 ```

--- a/packages/docs/pages/devguide/dependencies.mdx
+++ b/packages/docs/pages/devguide/dependencies.mdx
@@ -16,7 +16,7 @@ Uninstalling a dependency can be done via `pnpm --filter @frachtwerk/essencium-<
 
 ## Updating dependencies
 
-Essencium uses [Renovate](https://www.mend.io/renovate/) to automate the process of updating dependencies. A pull request for each dependency update will be created automatically.
+Essencium uses [Dependabot](https://github.com/dependabot) to automate the process of updating dependencies. A pull request for each dependency update will be created automatically.
 
 Dependencies should be updated regularly to keep Essencium up-to-date with the latest security patches, bug fixes, and performance improvements.
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "labels": ["dependency"]
-}


### PR DESCRIPTION
**DESCRIPTION**
 
This PR removes Renovate in favour of Dependabot which is built-in inside GitHub. I removed the Renovate config file and updated the docs. accordingly. Additionally I cleaned up the repo:

- closed all Renovate pull requests --> Dependabot creates own ones (currently configured only for `HIGH` vulnerabilities)
- 
 
**CLOSES**
 
Closes #404 