### PR TITLE
feat: add loading state to buttons

### DIFF
--- a/packages/lib/src/components/Profile/Profile.tsx
+++ b/packages/lib/src/components/Profile/Profile.tsx
@@ -27,6 +27,8 @@ type Props = {
   roles: RoleOutput[]
   handleUpdate: (data: UserUpdate) => void
   handlePasswordUpdate: (oldPassword: string, newPassword: string) => void
+  isLoadingUpdateUser: boolean
+  isLoadingUpdatePassword: boolean
 }
 
 export function Profile({
@@ -34,6 +36,8 @@ export function Profile({
   roles,
   handleUpdate,
   handlePasswordUpdate,
+  isLoadingUpdatePassword,
+  isLoadingUpdateUser,
 }: Props): JSX.Element {
   return (
     <Grid>
@@ -47,6 +51,8 @@ export function Profile({
           roles={roles}
           handleUpdate={handleUpdate}
           handlePasswordUpdate={handlePasswordUpdate}
+          isLoadingUpdatePassword={isLoadingUpdatePassword}
+          isLoadingUpdateUser={isLoadingUpdateUser}
         />
       </Grid.Col>
     </Grid>

--- a/packages/lib/src/components/Profile/Profile.tsx
+++ b/packages/lib/src/components/Profile/Profile.tsx
@@ -27,8 +27,8 @@ type Props = {
   roles: RoleOutput[]
   handleUpdate: (data: UserUpdate) => void
   handlePasswordUpdate: (oldPassword: string, newPassword: string) => void
-  isLoadingUpdateUser: boolean
-  isLoadingUpdatePassword: boolean
+  isUpdatingUser: boolean
+  isUpdatingPassword: boolean
 }
 
 export function Profile({
@@ -36,8 +36,8 @@ export function Profile({
   roles,
   handleUpdate,
   handlePasswordUpdate,
-  isLoadingUpdatePassword,
-  isLoadingUpdateUser,
+  isUpdatingPassword,
+  isUpdatingUser,
 }: Props): JSX.Element {
   return (
     <Grid>
@@ -51,8 +51,8 @@ export function Profile({
           roles={roles}
           handleUpdate={handleUpdate}
           handlePasswordUpdate={handlePasswordUpdate}
-          isLoadingUpdatePassword={isLoadingUpdatePassword}
-          isLoadingUpdateUser={isLoadingUpdateUser}
+          isUpdatingPassword={isUpdatingPassword}
+          isUpdatingUser={isUpdatingUser}
         />
       </Grid.Col>
     </Grid>

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
@@ -42,8 +42,8 @@ type Props = {
     oldPassword: PasswordChange['password'],
     newPassword: PasswordChange['password'],
   ) => void
-  isLoadingUpdateUser: boolean
-  isLoadingUpdatePassword: boolean
+  isUpdatingUser: boolean
+  isUpdatingPassword: boolean
 }
 
 export function ProfileDataCard({
@@ -51,8 +51,8 @@ export function ProfileDataCard({
   roles,
   handleUpdate,
   handlePasswordUpdate,
-  isLoadingUpdatePassword,
-  isLoadingUpdateUser,
+  isUpdatingPassword,
+  isUpdatingUser,
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
@@ -81,14 +81,14 @@ export function ProfileDataCard({
           <PersonalDataForm
             user={user}
             handleUpdate={handleUpdate}
-            isLoading={isLoadingUpdateUser}
+            isLoading={isUpdatingUser}
           />
         </Tabs.Panel>
 
         <Tabs.Panel value="passwordChange" pt="lg">
           <PasswordChangeForm
             handlePasswordUpdate={handlePasswordUpdate}
-            isLoading={isLoadingUpdatePassword}
+            isLoading={isUpdatingPassword}
           />
         </Tabs.Panel>
 
@@ -98,7 +98,7 @@ export function ProfileDataCard({
               user={user}
               handleUpdate={handleUpdate}
               roles={roles}
-              isLoading={isLoadingUpdateUser}
+              isLoading={isUpdatingUser}
             />
           </Tabs.Panel>
         ) : null}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
@@ -42,6 +42,8 @@ type Props = {
     oldPassword: PasswordChange['password'],
     newPassword: PasswordChange['password'],
   ) => void
+  isLoadingUpdateUser: boolean
+  isLoadingUpdatePassword: boolean
 }
 
 export function ProfileDataCard({
@@ -49,6 +51,8 @@ export function ProfileDataCard({
   roles,
   handleUpdate,
   handlePasswordUpdate,
+  isLoadingUpdatePassword,
+  isLoadingUpdateUser,
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
@@ -74,11 +78,18 @@ export function ProfileDataCard({
         </Tabs.List>
 
         <Tabs.Panel value="personalDataForm" pt="lg">
-          <PersonalDataForm user={user} handleUpdate={handleUpdate} />
+          <PersonalDataForm
+            user={user}
+            handleUpdate={handleUpdate}
+            isLoading={isLoadingUpdateUser}
+          />
         </Tabs.Panel>
 
         <Tabs.Panel value="passwordChange" pt="lg">
-          <PasswordChangeForm handlePasswordUpdate={handlePasswordUpdate} />
+          <PasswordChangeForm
+            handlePasswordUpdate={handlePasswordUpdate}
+            isLoading={isLoadingUpdatePassword}
+          />
         </Tabs.Panel>
 
         {router.pathname !== 'profile' ? (
@@ -87,6 +98,7 @@ export function ProfileDataCard({
               user={user}
               handleUpdate={handleUpdate}
               roles={roles}
+              isLoading={isLoadingUpdateUser}
             />
           </Tabs.Panel>
         ) : null}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
@@ -40,10 +40,12 @@ type Props = {
     oldPassword: PasswordChange['password'],
     newPassword: PasswordChange['password'],
   ) => void
+  isLoading: boolean
 }
 
 export function PasswordChangeForm({
   handlePasswordUpdate,
+  isLoading,
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
@@ -153,7 +155,7 @@ export function PasswordChangeForm({
           </Stack>
         </MediaQuery>
 
-        <Button type="submit" mt="md">
+        <Button type="submit" mt="md" loading={isLoading}>
           {t('profileView.dataCard.tabs.passwordChange.content.savePassword')}
         </Button>
       </Flex>

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.tsx
@@ -40,9 +40,14 @@ import { useZodForm } from '../../../../../hooks'
 type Props = {
   user: UserOutput
   handleUpdate: (data: UserUpdate) => void
+  isLoading: boolean
 }
 
-export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
+export function PersonalDataForm({
+  user,
+  handleUpdate,
+  isLoading,
+}: Props): JSX.Element {
   const { t } = useTranslation()
 
   const {
@@ -292,7 +297,7 @@ export function PersonalDataForm({ user, handleUpdate }: Props): JSX.Element {
         </Stack>
       </Flex>
 
-      <Button type="submit" mt="md">
+      <Button type="submit" mt="md" loading={isLoading}>
         {t('profileView.dataCard.tabs.personalData.saveChanges')}
       </Button>
     </form>

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/ProfileSettingsForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/ProfileSettingsForm.tsx
@@ -42,12 +42,14 @@ type Props = {
   user: UserOutput
   roles: RoleOutput[]
   handleUpdate: (data: UserUpdate) => void
+  isLoading: boolean
 }
 
 export function ProfileSettingsForm({
   user,
   roles,
   handleUpdate,
+  isLoading,
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
@@ -125,7 +127,7 @@ export function ProfileSettingsForm({
         </Box>
       </Flex>
 
-      <Button type="submit" mt="md">
+      <Button type="submit" mt="md" loading={isLoading}>
         {t('profileView.dataCard.tabs.settings.content.saveSettings')}
       </Button>
     </form>

--- a/packages/lib/src/components/Role/AddRole.tsx
+++ b/packages/lib/src/components/Role/AddRole.tsx
@@ -37,6 +37,7 @@ type Props = {
   createRole: (data: RoleInput) => void
   formDefaults: RoleInput
   toggleRight: (right: RightOutput) => void
+  isLoading: boolean
 }
 
 export function AddRole({
@@ -49,6 +50,7 @@ export function AddRole({
   createRole,
   formDefaults,
   toggleRight,
+  isLoading,
 }: Props): JSX.Element {
   const { handleSubmit, control, formState, reset } = useZodForm({
     schema: roleInputSchema,
@@ -75,6 +77,7 @@ export function AddRole({
         formState={formState}
         reset={reset}
         onClose={onClose}
+        isLoading={isLoading}
       />
     </Modal>
   )

--- a/packages/lib/src/components/Role/EditRole.tsx
+++ b/packages/lib/src/components/Role/EditRole.tsx
@@ -42,6 +42,7 @@ type Props = {
   updateRole: (data: RoleUpdate) => void
   toggleRight: (right: RightOutput) => void
   setSelectedRights: Dispatch<SetStateAction<RightOutput[]>>
+  isLoading: boolean
 }
 
 export function EditRole({
@@ -56,6 +57,7 @@ export function EditRole({
   updateRole,
   toggleRight,
   setSelectedRights,
+  isLoading,
 }: Props): JSX.Element {
   useEffect(() => {
     if (!role) return
@@ -109,6 +111,7 @@ export function EditRole({
           onClose()
           setSelectedRights([])
         }}
+        isLoading={isLoading}
       />
     </Modal>
   )

--- a/packages/lib/src/components/Role/components/RoleForm.tsx
+++ b/packages/lib/src/components/Role/components/RoleForm.tsx
@@ -47,6 +47,7 @@ type Props = {
   reset?: () => void
   onClose: () => void
   role?: RoleOutput
+  isLoading: boolean
 }
 
 export function RoleForm({
@@ -58,6 +59,7 @@ export function RoleForm({
   onClose,
   role,
   reset,
+  isLoading,
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
@@ -200,7 +202,7 @@ export function RoleForm({
       <Space h="lg" />
 
       <Flex justify="space-around" gap="lg">
-        <Button type="submit" fullWidth mt="md">
+        <Button type="submit" fullWidth mt="md" loading={isLoading}>
           {role ? t('rolesView.modal.update') : t('rolesView.modal.submit')}
         </Button>
 

--- a/packages/lib/src/components/User/UserForm.tsx
+++ b/packages/lib/src/components/User/UserForm.tsx
@@ -45,6 +45,7 @@ type Props = {
   formState: FormState<UserInput | UserUpdate>
   setValue: UseFormSetValue<UserInput | UserUpdate>
   onSubmit: () => void
+  isLoading: boolean
 }
 
 export function UserForm({
@@ -53,6 +54,7 @@ export function UserForm({
   control,
   formState,
   onSubmit,
+  isLoading,
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
@@ -343,7 +345,7 @@ export function UserForm({
         </Stack>
       </Flex>
 
-      <Button type="submit" mt="md">
+      <Button type="submit" mt="md" loading={isLoading}>
         {t('addUpdateUserView.form.save')}
       </Button>
     </form>

--- a/packages/lib/src/views/AddUserView.tsx
+++ b/packages/lib/src/views/AddUserView.tsx
@@ -40,7 +40,7 @@ export function AddUserView(): JSX.Element {
     defaultValues: FORM_DEFAULTS_USERS_VIEW,
   })
 
-  const { mutate: addUser } = useCreateUser()
+  const { mutate: addUser, isLoading } = useCreateUser()
 
   const { data: rolesResponse } = useGetRoles({
     page: 0,
@@ -77,6 +77,7 @@ export function AddUserView(): JSX.Element {
           control={control}
           formState={formState}
           setValue={setValue}
+          isLoading={isLoading}
         />
       </Card>
     </>

--- a/packages/lib/src/views/ProfileView.tsx
+++ b/packages/lib/src/views/ProfileView.tsx
@@ -35,9 +35,10 @@ export function ProfileView(): JSX.Element {
 
   const { data: user, isLoading: isLoadingUser } = useGetMe()
 
-  const { mutate: updateUser } = useUpdateMe()
+  const { mutate: updateUser, isLoading: isLoadingUpdateUser } = useUpdateMe()
 
-  const { mutate: updatePassword } = useUpdatePassword()
+  const { mutate: updatePassword, isLoading: isLoadingUpdatePassword } =
+    useUpdatePassword()
 
   const { data: rolesRequest } = useGetRoles({ page: 0, size: 9999 })
 
@@ -72,6 +73,8 @@ export function ProfileView(): JSX.Element {
         roles={roles}
         handleUpdate={handleUpdate}
         handlePasswordUpdate={handlePasswordUpdate}
+        isLoadingUpdateUser={isLoadingUpdateUser}
+        isLoadingUpdatePassword={isLoadingUpdatePassword}
       />
     )
   }

--- a/packages/lib/src/views/ProfileView.tsx
+++ b/packages/lib/src/views/ProfileView.tsx
@@ -35,9 +35,9 @@ export function ProfileView(): JSX.Element {
 
   const { data: user, isLoading: isLoadingUser } = useGetMe()
 
-  const { mutate: updateUser, isLoading: isLoadingUpdateUser } = useUpdateMe()
+  const { mutate: updateUser, isLoading: isUpdatingUser } = useUpdateMe()
 
-  const { mutate: updatePassword, isLoading: isLoadingUpdatePassword } =
+  const { mutate: updatePassword, isLoading: isUpdatingPassword } =
     useUpdatePassword()
 
   const { data: rolesRequest } = useGetRoles({ page: 0, size: 9999 })
@@ -73,8 +73,8 @@ export function ProfileView(): JSX.Element {
         roles={roles}
         handleUpdate={handleUpdate}
         handlePasswordUpdate={handlePasswordUpdate}
-        isLoadingUpdateUser={isLoadingUpdateUser}
-        isLoadingUpdatePassword={isLoadingUpdatePassword}
+        isUpdatingUser={isUpdatingUser}
+        isUpdatingPassword={isUpdatingPassword}
       />
     )
   }

--- a/packages/lib/src/views/RolesView.tsx
+++ b/packages/lib/src/views/RolesView.tsx
@@ -110,9 +110,9 @@ export function RolesView(): JSX.Element {
 
   const { data: rights } = useGetRights({ page: 0, size: 9999 })
 
-  const { mutate: createRole } = useCreateRole()
+  const { mutate: createRole, isLoading: isLoadingCreateRole } = useCreateRole()
 
-  const { mutate: updateRole } = useUpdateRole()
+  const { mutate: updateRole, isLoading: isLoadingUpdateRole } = useUpdateRole()
 
   const { mutate: deleteRole } = useDeleteRole()
 
@@ -323,6 +323,7 @@ export function RolesView(): JSX.Element {
         createRole={handleCreateRole}
         toggleRight={toggleRight}
         formDefaults={FORM_DEFAULTS_ROLES_VIEW}
+        isLoading={isLoadingCreateRole}
       />
 
       <EditRole
@@ -341,6 +342,7 @@ export function RolesView(): JSX.Element {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         role={roleToEditOrDelete!}
         setSelectedRights={setSelectedRights}
+        isLoading={isLoadingUpdateRole}
       />
 
       <DeleteDialog

--- a/packages/lib/src/views/RolesView.tsx
+++ b/packages/lib/src/views/RolesView.tsx
@@ -110,9 +110,9 @@ export function RolesView(): JSX.Element {
 
   const { data: rights } = useGetRights({ page: 0, size: 9999 })
 
-  const { mutate: createRole, isLoading: isLoadingCreateRole } = useCreateRole()
+  const { mutate: createRole, isLoading: isCreatingRole } = useCreateRole()
 
-  const { mutate: updateRole, isLoading: isLoadingUpdateRole } = useUpdateRole()
+  const { mutate: updateRole, isLoading: isUpdatingRole } = useUpdateRole()
 
   const { mutate: deleteRole } = useDeleteRole()
 
@@ -323,7 +323,7 @@ export function RolesView(): JSX.Element {
         createRole={handleCreateRole}
         toggleRight={toggleRight}
         formDefaults={FORM_DEFAULTS_ROLES_VIEW}
-        isLoading={isLoadingCreateRole}
+        isLoading={isCreatingRole}
       />
 
       <EditRole
@@ -342,7 +342,7 @@ export function RolesView(): JSX.Element {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         role={roleToEditOrDelete!}
         setSelectedRights={setSelectedRights}
-        isLoading={isLoadingUpdateRole}
+        isLoading={isUpdatingRole}
       />
 
       <DeleteDialog

--- a/packages/lib/src/views/UpdateUserView.tsx
+++ b/packages/lib/src/views/UpdateUserView.tsx
@@ -62,7 +62,7 @@ export function UpdateUserView(): JSX.Element {
     }
   }, [user, prefillForm])
 
-  const { mutate: updateUser } = useUpdateUser()
+  const { mutate: updateUser, isLoading } = useUpdateUser()
 
   const { data: rolesResponse } = useGetRoles({
     page: 0,
@@ -99,6 +99,7 @@ export function UpdateUserView(): JSX.Element {
           control={control}
           formState={formState}
           setValue={setValue}
+          isLoading={isLoading}
         />
       </Card>
     </>


### PR DESCRIPTION
**DESCRIPTION:**
A loading state has been added to the submit buttons in 

- Add Users & Update Users  
- Add Roles & Update Roles 
- Update Profile: Personal Data, Password and Settings 

While the button is in loading state, the icon is replaced with the loading spinner and the button gets disabled with a light overlay. 

Closes #405 
