### PR TITLE
fix: adjust margin in AuthLayout for mobile screens

### DIFF
--- a/packages/lib/src/components/NavBar/NavBar.tsx
+++ b/packages/lib/src/components/NavBar/NavBar.tsx
@@ -132,9 +132,23 @@ export function NavBar({
                       sx={{ cursor: 'pointer' }}
                     >
                       {fixedNav ? (
-                        <IconPinFilled size={20} color="black" />
+                        <IconPinFilled
+                          size={20}
+                          color={
+                            theme.colorScheme === 'dark'
+                              ? theme.colors.gray[3]
+                              : theme.colors.dark[9]
+                          }
+                        />
                       ) : (
-                        <IconPinnedOff size={20} color="black" />
+                        <IconPinnedOff
+                          size={20}
+                          color={
+                            theme.colorScheme === 'dark'
+                              ? theme.colors.gray[3]
+                              : theme.colors.dark[9]
+                          }
+                        />
                       )}
                     </Box>
                   ) : null}

--- a/packages/lib/src/layouts/AuthLayout.tsx
+++ b/packages/lib/src/layouts/AuthLayout.tsx
@@ -258,7 +258,7 @@ export function AuthLayout({
   const isNoPhone = useMediaQuery('(min-width: 48em)')
 
   function getSidebarMargin(): string {
-    if (isFixedNav) {
+    if (isFixedNav && isNoPhone) {
       return '250px'
     }
     if (isNoPhone) {


### PR DESCRIPTION
In this PR the margin in the AuthLayout has been adjusted, so that there is no unnecessary margin on smaller screen sizes. Additionally the color for the icon to fix the menu has been adjusted to dark mode. 

closes #433 