### PR TITLE
feat: use params to redirect after login

### DIFF
--- a/packages/lib/src/layouts/AuthLayout.tsx
+++ b/packages/lib/src/layouts/AuthLayout.tsx
@@ -192,7 +192,12 @@ export function AuthLayout({
   useEffect(() => {
     const authToken = localStorage.getItem('authToken')
 
-    if (!authToken) router.push('/login')
+    if (!authToken) {
+      router.push({
+        pathname: '/login',
+        query: { redirect: router.asPath },
+      })
+    }
   }, [user, router])
 
   useEffect(() => {

--- a/packages/lib/src/views/LoginView.tsx
+++ b/packages/lib/src/views/LoginView.tsx
@@ -18,6 +18,7 @@
  */
 
 import { ResetPassword } from '@frachtwerk/essencium-types'
+import { useSearchParams } from 'next/navigation'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { useState } from 'react'
@@ -32,6 +33,8 @@ export function LoginView(): JSX.Element {
 
   const router = useRouter()
 
+  const searchParams = useSearchParams()
+
   const { mutate: resetPassword, isLoading: isResettingPassword } =
     useResetPassword()
   const [isResetPasswordSent, setIsResetPasswordSent] = useState(false)
@@ -44,7 +47,7 @@ export function LoginView(): JSX.Element {
     createToken(
       { username, password },
       {
-        onSuccess: () => router.push('/'),
+        onSuccess: () => router.push(searchParams.get('redirect') || '/'),
         onError: () => {
           withBaseStylingShowNotification({
             title: t('loginView.errorMessage.title'),


### PR DESCRIPTION
In this PR the margin in the AuthLayout and LoginView has been adjusted, so that the user is redirected to the desired path after login.
First, if the user is not logged in the 'redirect' params are set while user is forwarded to login. In LoginView the user is forwarded to the path in the redirect params after successful login.

Closes #440 