### PR TITLE
docs: update codestyle and linting page

### DIFF
--- a/packages/docs/pages/devguide/_meta.json
+++ b/packages/docs/pages/devguide/_meta.json
@@ -1,6 +1,6 @@
 {
   "setup": "Setup",
-  "codestyle-and-linting": "Code style and linting 📝",
+  "codestyle-and-linting": "Code style and linting",
   "packageResponsibilities": "Package responsibilities",
   "dependencies": "Dependencies",
   "new-page": "New Page",

--- a/packages/docs/pages/devguide/codestyle-and-linting.mdx
+++ b/packages/docs/pages/devguide/codestyle-and-linting.mdx
@@ -1,42 +1,53 @@
-import { Callout } from 'nextra-theme-docs'
-
-<Callout type="warning" emoji="⚠️">
-  Some sections are still drafts and marked with a 📝 symbol. Feel free to
-  contribute 🎉.
-  <ul>
-    <li>- add Prettier rules explanation</li>
-    <li>- check intro paragraph if the order of context makes sense</li>
-  </ul>
-</Callout>
-
 # Code style and linting
 
-For enforcing code style and utilizing static code analyzing we use ESLint along with a bunch of rulesets. The most
+For enforcing code style and utilizing static code analyzing we use [ESLint](https://eslint.org/) along with a bunch of rulesets and [Prettier](https://prettier.io/). The most
 noteworthy ruleset is the [Airbnb JavaScript Style Guide](https://airbnb.io/javascript/react/).
 
-We chose this approach because it provides strict but conventional rules. You can always execute the commands
-`pnpm format` to apply the Prettier formatting settings for all project files inside the `src`-directory, or `pnpm lint`
+We choose this approach because it provides strict but conventional rules. You can always execute the commands
+`pnpm format:(check|write)` to apply the Prettier formatting settings for all project files inside the `src`-directory, or `pnpm lint`
 to lint all projects files inside the `src`-directory based on the ESLint configuration.
 
 We modified some rules to fit our code style. By default, ESLint will display an error if any rule is not satisfied. We
 don't work with warnings.
 
 Our Prettier and ESLint configurations are located in own packages that get published to npm. This way we can easily
-share the configuration between projects and keep them up to date.
+share the configuration between projects and keep them up to date consistently.
 
-## `"react/react-in-jsx-scope": "off"`
+## Explanation Prettier rules
+
+We use the [default Prettier rules](https://prettier.io/docs/en/options.html) and overwrite the following ones:
+
+### `"semi": false`
+
+Prevents printing semicolons at the end of statements.
+
+### `"singleQuote": true`
+
+Use single quotes instead of double quotes.
+
+### `"arrowParens": "avoid"`
+
+Do not include parentheses around a sole arrow function parameter.
+
+### `"bracketSpacing": true`
+
+Print spaces between brackets in object literals.
+
+## Explanation ESLint rules
+
+### `"react/react-in-jsx-scope": "off"`
 
 This rule automatically imports the `react` package in our file when we use JSX.
 
-## `"react/jsx-props-no-spreading": "off"`
+### `"react/jsx-props-no-spreading": "off"`
 
 Allow spreading props into components.
 
-## `"react/require-default-props": "off"`
+### `"react/require-default-props": "off"`
 
 Disable the requirement of default props for components.
 
-## `"react/jsx-no-bind"`
+### `"react/jsx-no-bind"`
 
 ```json
 ["error", { "allowFunctions": true, "allowArrowFunctions": true }]
@@ -44,19 +55,19 @@ Disable the requirement of default props for components.
 
 Allow passing function references (expressions and declarations) as callbacks to component props.
 
-## `"simple-import-sort/imports": "error"`
+### `"simple-import-sort/imports": "error"`
 
 To keep our import order consistent we chose to let it auto-sort by this ESLint plugin.
 
-## `"simple-import-sort/exports": "error"`
+### `"simple-import-sort/exports": "error"`
 
 To keep our export order consistent we chose to let it auto-sort by this ESLint plugin.
 
-## `"prettier/prettier": "error"`
+### `"prettier/prettier": "error"`
 
 If any rule from the `.prettierrc.json` is not met, throw an error.
 
-## `"import/extensions"`
+### `"import/extensions"`
 
 ```json
 [
@@ -74,7 +85,7 @@ If any rule from the `.prettierrc.json` is not met, throw an error.
 
 Allow omitting file extensions when importing either a `.js`, `.jsx`, `.ts` or `.tsx` file.
 
-## `"import/no-extraneous-dependencies"`
+### `"import/no-extraneous-dependencies"`
 
 ```json
 [
@@ -95,11 +106,11 @@ Allow omitting file extensions when importing either a `.js`, `.jsx`, `.ts` or `
 Forbid the import of external modules that are not declared in the `package.json`'s dependencies, devDependencies,
 optionalDependencies, peerDependencies, or bundledDependencies.
 
-## `"import/prefer-default-export": "off"`
+### `"import/prefer-default-export": "off"`
 
 Do not prefer default export.
 
-## `"@nrwl/nx/enforce-module-boundaries"`
+### `"@nrwl/nx/enforce-module-boundaries"`
 
 ```json
 [
@@ -127,7 +138,7 @@ Do not prefer default export.
 Here we set contraints which package can import other packages inside the `packages` folder. For example, it does not
 make sense to import anything from `app` in `lib` but vice versa.
 
-## `"@typescript-eslint/explicit-function-return-type"`
+### `"@typescript-eslint/explicit-function-return-type"`
 
 ```json
 [
@@ -142,6 +153,6 @@ Always pass the return type of a **function declaration**. As we follow the rule
 expressions for 'standalone' functions (not as callback) it makes sense to enforce the rule only for function
 declarations.
 
-## `"consistent-return": "off"`
+### `"consistent-return": "off"`
 
 We disabled the rule due to the fact that we don't want to return `undefined` in every function explicitly.


### PR DESCRIPTION
**DESCRIPTION**
 
This PR updates the section [Code style and linting](https://docs.essencium.dev/devguide/codestyle-and-linting) by adding an explanation for the used Prettier rules and other minor changes.
 
**CLOSES**
 
Closes #394 