### PR TITLE
docs: update architecture sections and config package links

### DIFF
--- a/packages/docs/pages/architecture.mdx
+++ b/packages/docs/pages/architecture.mdx
@@ -34,16 +34,22 @@ That gives us the following architecture:
 │   │   ├── package.json
 │   │   └── ...
 ├── scripts
+│   ├── seed-db.ts
 ├── .commitlintrc.json
 ├── .eslintrc.json
 ├── .gitignore
+├── .lintstagedrc.json
 ├── .npmrc
-├── .prettierrc.json
+├── .prettierrc
 ├── .release-please-manifest.json
+├── CODE_OF_CONDUCT.md
+├── CONTRIBUTION.md
+├── LICENSE.md
 ├── nx.json
 ├── package.json
 ├── pnpm-lock.yaml
 ├── pnpm-workspace.yaml
+├── pull_request_template.md
 ├── README.md
 ├── release-please-config.json
 └── tsconfig.json

--- a/packages/docs/pages/devguide/codestyle-and-linting.mdx
+++ b/packages/docs/pages/devguide/codestyle-and-linting.mdx
@@ -10,7 +10,7 @@ to lint all projects files inside the `src`-directory based on the ESLint config
 We modified some rules to fit our code style. By default, ESLint will display an error if any rule is not satisfied. We
 don't work with warnings.
 
-Our Prettier and ESLint configurations are located in own packages that get published to npm. This way we can easily
+Our Prettier and ESLint configurations are located in own packages ([`eslint-config`](http://localhost:3000/devguide/packageResponsibilities#eslint-config) & [`prettier-config`](http://localhost:3000/devguide/packageResponsibilities#prettier-config)) that get published to [npm](https://www.npmjs.com/~f9w?activeTab=packages). This way we can easily
 share the configuration between projects and keep them up to date consistently.
 
 ## Explanation Prettier rules

--- a/packages/docs/pages/devguide/packageResponsibilities.mdx
+++ b/packages/docs/pages/devguide/packageResponsibilities.mdx
@@ -14,13 +14,15 @@ The challenge is to maintain separation of concerns for each package. The follow
 
 ## `app`
 
-- the main application that consumes the `lib` & `types` package
-- Next.js pages that import components from `lib`
+- the main application that consumes the `lib`, `eslint-config`, `prettier-config` & `types` package
+- Next.js pages that import components from `lib` and types from `types`
+- ESLint and Prettier apply the shared configuration from `eslint-config` and `prettier-config`
 - API implementation
 - application state
 - routing (via [Next.js pages router](https://nextjs.org/docs/pages))
 - error logging (via [Sentry](https://sentry.io/))
 - E2E tests (via [Playwright](https://playwright.dev/))
+- unit tests (via [Vitest](https://vitest.dev/))
 
 ## `docs` (this)
 


### PR DESCRIPTION
## DESCRIPTION

This PR updates the sections where we describe the architecture or the monorepo packages since we had several changes in the near past. Additionally, I added some links to relevant keywords.

### TO-DO

- ~~implement and update tests~~
- [x] update docs
- [x] pull `main` & resolve merge conflicts

### CLOSES

#454 