### PR TITLE
fix: set inital state of foldedNav to true

### DIFF
--- a/packages/lib/src/components/NavBar/NavBar.tsx
+++ b/packages/lib/src/components/NavBar/NavBar.tsx
@@ -68,7 +68,7 @@ export function NavBar({
 
   const { t } = useTranslation()
 
-  const { start, clear } = useTimeout(() => setFoldedNav(false), 270)
+  const { start, clear } = useTimeout(() => setFoldedNav(true), 270)
 
   function toggleFixedNav(): void {
     setFixedNav(fixed => !fixed)


### PR DESCRIPTION
## DESCRIPTION

The inital state of the state isFolded was set to false which caused the error.

### TO-DO

- [ ] implement and update tests
- [ ] ~~update docs~~
- [x] pull `main` & resolve merge conflicts

### CLOSES

https://github.com/Frachtwerk/essencium-frontend/issues/447
