### PR TITLE
feat: customize LoadingSpinner Component

### DIFF
--- a/packages/app/src/pages/profile/index.tsx
+++ b/packages/app/src/pages/profile/index.tsx
@@ -17,9 +17,9 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Profile } from '@frachtwerk/essencium-lib'
+import { LoadingSpinner, Profile } from '@frachtwerk/essencium-lib'
 import { PasswordChange, UserUpdate } from '@frachtwerk/essencium-types'
-import { Center, Loader } from '@mantine/core'
+import { Center } from '@mantine/core'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { ReactElement } from 'react'
@@ -81,11 +81,7 @@ function ProfileView(): JSX.Element {
   }
 
   if (isLoadingUser) {
-    return (
-      <Center h="100%">
-        <Loader size="xl" name="loader" />
-      </Center>
-    )
+    return <LoadingSpinner show />
   }
 
   return (

--- a/packages/app/src/pages/rights/index.tsx
+++ b/packages/app/src/pages/rights/index.tsx
@@ -20,6 +20,7 @@
 /* eslint-disable react/no-unstable-nested-components */
 import {
   HttpNotification,
+  LoadingSpinner,
   Table,
   TablePagination,
 } from '@frachtwerk/essencium-lib'
@@ -29,15 +30,7 @@ import {
   RoleOutput,
   RoleUpdate,
 } from '@frachtwerk/essencium-types'
-import {
-  Button,
-  Center,
-  Checkbox,
-  Flex,
-  Loader,
-  Text,
-  Title,
-} from '@mantine/core'
+import { Button, Checkbox, Flex, Text, Title } from '@mantine/core'
 import { IconShieldHalf } from '@tabler/icons-react'
 import {
   ColumnDef,
@@ -245,9 +238,7 @@ function RightsView(): JSX.Element {
       </Flex>
 
       {isLoadingRights ? (
-        <Center h="100%">
-          <Loader size="xl" name="loader" />
-        </Center>
+        <LoadingSpinner show />
       ) : (
         <>
           <Table tableModel={table} firstColSticky />

--- a/packages/app/src/pages/roles/index.tsx
+++ b/packages/app/src/pages/roles/index.tsx
@@ -24,6 +24,7 @@ import {
   DeleteDialog,
   EditRole,
   HttpNotification,
+  LoadingSpinner,
   Table,
   TablePagination,
 } from '@frachtwerk/essencium-lib'
@@ -37,9 +38,7 @@ import {
   ActionIcon,
   Badge,
   Button,
-  Center,
   Flex,
-  Loader,
   Text,
   Title,
   useMantineTheme,
@@ -364,9 +363,7 @@ function RolesView(): JSX.Element {
       />
 
       {isLoadingRoles ? (
-        <Center h="100%">
-          <Loader size="xl" name="loader" />
-        </Center>
+        <LoadingSpinner show />
       ) : (
         <>
           <Table tableModel={table} />

--- a/packages/app/src/pages/users/index.tsx
+++ b/packages/app/src/pages/users/index.tsx
@@ -21,6 +21,7 @@
 import {
   DeleteDialog,
   HttpNotification,
+  LoadingSpinner,
   Table,
   TablePagination,
 } from '@frachtwerk/essencium-lib'
@@ -34,10 +35,8 @@ import {
   ActionIcon,
   Badge,
   Button,
-  Center,
   Flex,
   Group,
-  Loader,
   Popover,
   Switch,
   Text,
@@ -433,9 +432,7 @@ function UsersView(): JSX.Element {
         />
 
         {isLoadingUsers ? (
-          <Center h="100%">
-            <Loader size="xl" name="loader" />
-          </Center>
+          <LoadingSpinner show />
         ) : (
           <>
             <Table

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -32,7 +32,6 @@ import {
   Dialog,
   Flex,
   Group,
-  Loader,
   rem,
   Stack,
   Text,
@@ -60,6 +59,7 @@ import { ReactNode, useEffect, useState } from 'react'
 import { Controller } from 'react-hook-form'
 
 import { useZodForm } from '../../hooks'
+import { LoadingSpinner } from '../LoadingSpinner'
 
 type NotificationParams = {
   notificationType: 'created' | 'updated' | 'deleted'
@@ -276,9 +276,7 @@ export function FeedbackWidget({
               <Box>
                 {isLoading ? (
                   <Box h={rem(100)}>
-                    <Center>
-                      <Loader mt="xl" />
-                    </Center>
+                    <LoadingSpinner show size="lg" />
                   </Box>
                 ) : null}
 

--- a/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -17,43 +17,23 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Container, DefaultMantineColor, Loader } from '@mantine/core'
+import { Container, Loader, LoaderProps } from '@mantine/core'
 import { useEffect, useState } from 'react'
 
-const LoaderVariants = {
-  Bars: 'bars',
-  Oval: 'oval',
-  Dots: 'dots',
-} as const
-
-export type LoaderVariantTypeValues =
-  (typeof LoaderVariants)[keyof typeof LoaderVariants]
-
-const LoaderSizes = {
-  Xs: 'xs',
-  Sm: 'sm',
-  Md: 'md',
-  Lg: 'lg',
-  Xl: 'xl',
-} as const
-
-export type LoaderSizeTypeValues =
-  (typeof LoaderSizes)[keyof typeof LoaderSizes]
-
-interface Props {
+type Props = {
   show: boolean
   delay?: number
-  color?: DefaultMantineColor
-  size?: LoaderSizeTypeValues | number
-  variant?: LoaderVariantTypeValues
+  color?: LoaderProps['color']
+  size?: LoaderProps['size']
+  variant?: LoaderProps['variant']
 }
 
 export function LoadingSpinner({
   show = false,
   delay = 0,
   color = 'blue',
-  size = LoaderSizes.Xl,
-  variant = LoaderVariants.Dots,
+  size = 'xl',
+  variant = 'dots',
 }: Props): JSX.Element | null {
   const [showSpinner, setShowSpinner] = useState(false)
 

--- a/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -17,7 +17,7 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Container, Loader } from '@mantine/core'
+import { Container, DefaultMantineColor, Loader } from '@mantine/core'
 import { useEffect, useState } from 'react'
 
 const LoaderVariants = {
@@ -43,7 +43,7 @@ export type LoaderSizeTypeValues =
 interface Props {
   show: boolean
   delay?: number
-  color?: string
+  color?: DefaultMantineColor
   size?: LoaderSizeTypeValues | number
   variant?: LoaderVariantTypeValues
 }
@@ -52,8 +52,8 @@ export function LoadingSpinner({
   show = false,
   delay = 0,
   color = 'blue',
-  size = 'xl',
-  variant = 'dots',
+  size = LoaderSizes.Xl,
+  variant = LoaderVariants.Dots,
 }: Props): JSX.Element | null {
   const [showSpinner, setShowSpinner] = useState(false)
 

--- a/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -17,17 +17,43 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Loader } from '@mantine/core'
+import { Container, Loader } from '@mantine/core'
 import { useEffect, useState } from 'react'
+
+const LoaderVariants = {
+  Bars: 'bars',
+  Oval: 'oval',
+  Dots: 'dots',
+} as const
+
+export type LoaderVariantTypeValues =
+  (typeof LoaderVariants)[keyof typeof LoaderVariants]
+
+const LoaderSizes = {
+  Xs: 'xs',
+  Sm: 'sm',
+  Md: 'md',
+  Lg: 'lg',
+  Xl: 'xl',
+} as const
+
+export type LoaderSizeTypeValues =
+  (typeof LoaderSizes)[keyof typeof LoaderSizes]
 
 interface Props {
   show: boolean
   delay?: number
+  color?: string
+  size?: LoaderSizeTypeValues | number
+  variant?: LoaderVariantTypeValues
 }
 
 export function LoadingSpinner({
   show = false,
   delay = 0,
+  color = 'blue',
+  size = 'xl',
+  variant = 'dots',
 }: Props): JSX.Element | null {
   const [showSpinner, setShowSpinner] = useState(false)
 
@@ -50,5 +76,16 @@ export function LoadingSpinner({
     }
   }, [show, delay])
 
-  return showSpinner ? <Loader size="xl" name="loader" /> : null
+  return showSpinner ? (
+    <Container
+      style={{
+        top: '50%',
+        left: '50%',
+        position: 'absolute',
+        transform: 'translate(-50%, -50%)',
+      }}
+    >
+      <Loader size={size} color={color} variant={variant} name="loader" />
+    </Container>
+  ) : null
 }

--- a/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -25,9 +25,7 @@ type Props = LoaderProps & { show: boolean; delay?: number }
 export function LoadingSpinner({
   show = false,
   delay = 0,
-  color,
   size = 'xl',
-  variant = 'dots',
   ...props
 }: Props): JSX.Element | null {
   const [showSpinner, setShowSpinner] = useState(false)
@@ -60,13 +58,7 @@ export function LoadingSpinner({
         transform: 'translate(-50%, -50%)',
       }}
     >
-      <Loader
-        size={size}
-        color={color}
-        variant={variant}
-        name="loader"
-        {...props}
-      />
+      <Loader name="loader" size={size} {...props} />
     </Container>
   ) : null
 }

--- a/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -20,20 +20,15 @@
 import { Container, Loader, LoaderProps } from '@mantine/core'
 import { useEffect, useState } from 'react'
 
-type Props = {
-  show: boolean
-  delay?: number
-  color?: LoaderProps['color']
-  size?: LoaderProps['size']
-  variant?: LoaderProps['variant']
-}
+type Props = LoaderProps & { show: boolean; delay?: number }
 
 export function LoadingSpinner({
   show = false,
   delay = 0,
-  color = 'blue',
+  color,
   size = 'xl',
   variant = 'dots',
+  ...props
 }: Props): JSX.Element | null {
   const [showSpinner, setShowSpinner] = useState(false)
 
@@ -65,7 +60,13 @@ export function LoadingSpinner({
         transform: 'translate(-50%, -50%)',
       }}
     >
-      <Loader size={size} color={color} variant={variant} name="loader" />
+      <Loader
+        size={size}
+        color={color}
+        variant={variant}
+        name="loader"
+        {...props}
+      />
     </Container>
   ) : null
 }

--- a/packages/lib/src/components/Login/components/LoginForm/LoginForm.tsx
+++ b/packages/lib/src/components/Login/components/LoginForm/LoginForm.tsx
@@ -26,9 +26,7 @@ import {
   Anchor,
   Box,
   Button,
-  Center,
   Group,
-  Loader,
   Paper,
   PasswordInput,
   Text,
@@ -40,6 +38,7 @@ import { Dispatch, SetStateAction } from 'react'
 import { Controller } from 'react-hook-form'
 
 import { useZodForm } from '../../../../hooks'
+import { LoadingSpinner } from '../../../LoadingSpinner'
 import { ResetPasswordForm, ResetPasswordSuccessMessage } from './components'
 
 type Props = {
@@ -181,11 +180,7 @@ export function LoginForm({
         )}
       </Transition>
 
-      {isResettingPassword && (
-        <Center h="100%">
-          <Loader size="lg" name="loader" />
-        </Center>
-      )}
+      {isResettingPassword && <LoadingSpinner show size="lg" />}
 
       <Transition
         mounted={isResetPasswordSent}


### PR DESCRIPTION
## DESCRIPTION

In this PR, the LoadingSpinner component has been customized: 
- it can now consume all Mantine component props
- it is centered vertically and horizontally on the page
- all default Loader components have been exchanged with the LoadingSpinner component 


### TO-DO

- [ ] ~~implement and update tests~~
- [ ] ~~update docs~~
- [X] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #444 
