### PR TITLE
refactor: change color from string to theme color

### DIFF
--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -206,7 +206,6 @@ export function FeedbackWidget({
     <>
       <ActionIcon
         variant="filled"
-        color={theme.primaryColor}
         size="xl"
         radius="xl"
         style={{
@@ -243,7 +242,6 @@ export function FeedbackWidget({
               return (
                 <Stack key={key}>
                   <ActionIcon
-                    color={theme.primaryColor}
                     variant="filled"
                     size={70}
                     style={{ borderRadius: '20px' }}
@@ -289,7 +287,6 @@ export function FeedbackWidget({
                       {showSuccessMessage ? (
                         <ThemeIcon
                           variant="outline"
-                          color={theme.primaryColor}
                           style={{ border: 'none' }}
                           size={60}
                         >
@@ -375,7 +372,6 @@ export function FeedbackWidget({
                           <ActionIcon
                             variant={screenshot ? 'filled' : 'outline'}
                             size="md"
-                            color={theme.primaryColor}
                             onClick={() => captureScreenshot()}
                           >
                             {screenshot ? (

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -242,7 +242,7 @@ export function FeedbackWidget({
               return (
                 <Stack key={key}>
                   <ActionIcon
-                    color="blue"
+                    color={theme.colors.blue[6]}
                     variant="filled"
                     size={70}
                     style={{ borderRadius: '20px' }}
@@ -371,7 +371,7 @@ export function FeedbackWidget({
                           <ActionIcon
                             variant={screenshot ? 'filled' : 'outline'}
                             size="md"
-                            color="blue"
+                            color={theme.colors.blue[6]}
                             onClick={() => captureScreenshot()}
                           >
                             {screenshot ? (

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -37,6 +37,7 @@ import {
   Stack,
   Text,
   Textarea,
+  ThemeIcon,
   Title,
   Tooltip,
   Transition,
@@ -205,7 +206,7 @@ export function FeedbackWidget({
     <>
       <ActionIcon
         variant="filled"
-        color={theme.colors.blue[6]}
+        color={theme.primaryColor}
         size="xl"
         radius="xl"
         style={{
@@ -242,7 +243,7 @@ export function FeedbackWidget({
               return (
                 <Stack key={key}>
                   <ActionIcon
-                    color={theme.colors.blue[6]}
+                    color={theme.primaryColor}
                     variant="filled"
                     size={70}
                     style={{ borderRadius: '20px' }}
@@ -286,11 +287,14 @@ export function FeedbackWidget({
                   <Stack>
                     <Center>
                       {showSuccessMessage ? (
-                        <IconCircleCheck
+                        <ThemeIcon
+                          variant="outline"
+                          color={theme.primaryColor}
+                          style={{ border: 'none' }}
                           size={60}
-                          stroke={1.5}
-                          color={theme.colors.blue[6]}
-                        />
+                        >
+                          <IconCircleCheck size={60} stroke={1.5} />
+                        </ThemeIcon>
                       ) : (
                         <IconCircleX
                           size={60}
@@ -371,7 +375,7 @@ export function FeedbackWidget({
                           <ActionIcon
                             variant={screenshot ? 'filled' : 'outline'}
                             size="md"
-                            color={theme.colors.blue[6]}
+                            color={theme.primaryColor}
                             onClick={() => captureScreenshot()}
                           >
                             {screenshot ? (


### PR DESCRIPTION
## DESCRIPTION

In this PR the color of the action icons in the feedback widget has been changed. A hardcoded color string led to issues in Essencium based projects. By using the primary theme color, this should be solved. 

### TO-DO

- [ ] ~implement and update tests~
- [ ] ~update docs~
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #508 
