### PR TITLE
feat: close feedback widget on screen capture

### DIFF
--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -29,3 +29,7 @@
 .themeIcon {
   border: none;
 }
+
+.displayNone {
+  display: none;
+}

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -17,19 +17,19 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.textarea {
+.feedback-widget__textarea {
   border-radius: '50px';
   margin-bottom: '15px';
 }
 
-.actionIcon {
+.feedback-widget__action-icon {
   border-radius: '20px';
 }
 
-.themeIcon {
+.feedback-widget__theme-icon {
   border: none;
 }
 
-.displayNone {
+.feedback-widget__dialog--display {
   display: none;
 }

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -103,6 +103,9 @@ export function FeedbackWidget({
 
   const [screenshot, setScreenshot] = useState<string | null>(null)
 
+  const [isCapturingScreenshot, setIsCapturingScreenshot] =
+    useState<boolean>(false)
+
   const { handleSubmit, control, formState, reset, setValue } = useZodForm({
     schema: feedbackFormSchema,
     defaultValues: {
@@ -163,12 +166,20 @@ export function FeedbackWidget({
 
   function onCloseWidget(): void {
     close()
+
     reset()
+
     setOpenInput(null)
+
     setShowSuccessMessage(false)
+
     setShowErrorMessage(false)
+
     setIsLoading(false)
+
     setScreenshot(null)
+
+    setIsCapturingScreenshot(false)
   }
 
   function onSubmit(form: FeedbackInput): void {
@@ -188,9 +199,18 @@ export function FeedbackWidget({
   function captureScreenshot(): void {
     html2canvas(document.body).then(canvas => {
       const screenshotData = canvas.toDataURL('image/png')
+
       setScreenshot(screenshotData)
+
+      setIsCapturingScreenshot(false)
     })
   }
+
+  useEffect(() => {
+    if (isCapturingScreenshot) {
+      captureScreenshot()
+    }
+  }, [isCapturingScreenshot])
 
   useEffect(() => {
     if (screenshot) {
@@ -229,6 +249,7 @@ export function FeedbackWidget({
         w="390px"
         h={openInput ? 'auto' : '180px'}
         position={{ bottom: 100, right: 80 }}
+        className={isCapturingScreenshot ? classes.displayNone : ''}
       >
         {!showSuccessMessage || !showErrorMessage ? (
           <Title order={4} ta="center" size="sm" mb="sm" fw={500}>
@@ -365,11 +386,18 @@ export function FeedbackWidget({
                       </Box>
 
                       <Flex gap="xs">
-                        <Tooltip label={t('feedbackWidget.screenshot.label')}>
+                        <Tooltip
+                          label={t('feedbackWidget.screenshot.label')}
+                          className={
+                            isCapturingScreenshot ? classes.displayNone : ''
+                          }
+                        >
                           <ActionIcon
                             variant={screenshot ? 'filled' : 'outline'}
                             size="md"
-                            onClick={() => captureScreenshot()}
+                            onClick={() => {
+                              setIsCapturingScreenshot(true)
+                            }}
                           >
                             {screenshot ? (
                               <IconCameraCheck size={20} />

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -249,7 +249,11 @@ export function FeedbackWidget({
         w="390px"
         h={openInput ? 'auto' : '180px'}
         position={{ bottom: 100, right: 80 }}
-        className={isCapturingScreenshot ? classes.displayNone : ''}
+        className={
+          isCapturingScreenshot
+            ? classes['feedback-widget__dialog--display']
+            : ''
+        }
       >
         {!showSuccessMessage || !showErrorMessage ? (
           <Title order={4} ta="center" size="sm" mb="sm" fw={500}>
@@ -266,7 +270,7 @@ export function FeedbackWidget({
                   <ActionIcon
                     variant="filled"
                     size={70}
-                    className={classes['actionIcon']}
+                    className={classes['feedback-widget__action-icon']}
                     onClick={() => {
                       setOpenInput(OpenInput[inputKey])
                     }}
@@ -307,7 +311,7 @@ export function FeedbackWidget({
                       {showSuccessMessage ? (
                         <ThemeIcon
                           variant="outline"
-                          className={classes['themeIcon']}
+                          className={classes['feedback-widget__theme-icon']}
                           size={60}
                         >
                           <IconCircleCheck size={60} stroke={1.5} />
@@ -367,7 +371,7 @@ export function FeedbackWidget({
                         render={({ field }) => (
                           <Textarea
                             {...field}
-                            className={classes['textarea']}
+                            className={classes['feedback-widget__textarea']}
                             placeholder={
                               t('feedbackWidget.placeholder') as string
                             }
@@ -389,7 +393,9 @@ export function FeedbackWidget({
                         <Tooltip
                           label={t('feedbackWidget.screenshot.label')}
                           className={
-                            isCapturingScreenshot ? classes.displayNone : ''
+                            isCapturingScreenshot
+                              ? classes['feedback-widget__dialog--display']
+                              : ''
                           }
                         >
                           <ActionIcon


### PR DESCRIPTION
## DESCRIPTION

The feedback widget now gets closed on screen capture and opens again after the screenshot is made. 

### TO-DO

- [X] pull `main` & resolve merge conflicts
- [X] check Vercel deployment

### CLOSES

closes #542 
