### PR TITLE
refactor: refactor styles and css classes

### DIFF
--- a/packages/app/public/locales/de/common.json
+++ b/packages/app/public/locales/de/common.json
@@ -126,6 +126,9 @@
       "title": "Ihr Ansprechpartner",
       "avatar": {
         "alt": "Ansprechpartner Avatar"
+      },
+      "contactPerson": {
+        "ariaLabel": "Ansprechpartner"
       }
     }
   },

--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -126,6 +126,9 @@
       "title": "Your Contact Person",
       "avatar": {
         "alt": "Avatar contact person"
+      },
+      "contactPerson": {
+        "ariaLabel": "Contact Person"
       }
     }
   },

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -271,7 +271,7 @@ export function AuthLayout({
     }
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [router.events])
+  }, [router.events, userRights])
 
   function handleLogout(): void {
     logout()

--- a/packages/app/src/pages/login/Login.module.css
+++ b/packages/app/src/pages/login/Login.module.css
@@ -27,28 +27,24 @@
   margin-top: var(--mantine-spacing-md);
 }
 
-.ssoSection--link {
+.ssoSection__link {
   text-decoration: none;
   color: white;
 }
 
-.ssoSection--button {
+.ssoSection__button {
   margin: var(--mantine-spacing-xs) 0;
 }
 
-.ssoSection--button {
-  margin: var(--mantine-spacing-xs) 0;
-}
-
-.ssoSection--spacer {
+.ssoSection__spacer {
   margin: 0 var(--mantine-spacing-xs);
 }
 
-.ssoSection--divider {
+.ssoSection__divider {
   margin: var(--mantine-spacing-xl) 0;
 }
 
-.loginCard--title {
+.loginCard__title {
   text-align: center;
   font-weight: bold;
 }

--- a/packages/app/src/pages/login/Login.module.css
+++ b/packages/app/src/pages/login/Login.module.css
@@ -18,6 +18,9 @@
  */
 
 .loginCard {
+  box-shadow: var(--mantine-shadow-sm);
+  border-radius: var(--mantine-radius-sm);
+
   @mixin dark {
     background-color: var(--mantine-color-dark-7);
   }

--- a/packages/app/src/pages/login/index.tsx
+++ b/packages/app/src/pages/login/index.tsx
@@ -109,12 +109,7 @@ function LoginView(): JSX.Element {
   return (
     <Container mt="150px">
       {!oauthToken ? (
-        <Card
-          shadow="sm"
-          radius="sm"
-          className={classes['loginCard']}
-          withBorder
-        >
+        <Card className={classes['loginCard']} withBorder>
           <Flex direction="column">
             <Title order={2} className={classes['loginCard__title']}>
               {t('loginView.title')}

--- a/packages/app/src/pages/login/index.tsx
+++ b/packages/app/src/pages/login/index.tsx
@@ -116,7 +116,7 @@ function LoginView(): JSX.Element {
           withBorder
         >
           <Flex direction="column">
-            <Title order={2} className={classes['loginCard--title']}>
+            <Title order={2} className={classes['loginCard__title']}>
               {t('loginView.title')}
             </Title>
 
@@ -125,14 +125,14 @@ function LoginView(): JSX.Element {
                 <Box className={classes['ssoSection']}>
                   {Object.keys(ssoApplications).map(application => (
                     <NextLink
-                      className={classes['ssoSection--link']}
+                      className={classes['ssoSection__link']}
                       key={application}
                       href={`${process.env.NEXT_PUBLIC_API_BASE_URL}${ssoApplications[application].url}?redirect_uri=${OAUTH_REDIRECT_URI}`}
                     >
                       <Flex
                         justify="center"
                         align="center"
-                        className={classes['ssoSection--button']}
+                        className={classes['ssoSection__button']}
                       >
                         <Button
                           variant="outline"
@@ -146,7 +146,7 @@ function LoginView(): JSX.Element {
                             />
                           }
                         >
-                          <Box className={classes['ssoSection--spacer']} />
+                          <Box className={classes['ssoSection__spacer']} />
 
                           <Text>{ssoApplications[application].name}</Text>
                         </Button>
@@ -156,7 +156,7 @@ function LoginView(): JSX.Element {
                 </Box>
 
                 <Divider
-                  className={classes['ssoSection--divider']}
+                  className={classes['ssoSection__divider']}
                   label={t('loginView.sso.or')}
                   labelPosition="center"
                 />

--- a/packages/app/src/pages/profile/Profile.module.css
+++ b/packages/app/src/pages/profile/Profile.module.css
@@ -1,4 +1,4 @@
-.profile__center {
+.profile__container {
   width: 100%;
   height: 100%;
 }

--- a/packages/app/src/pages/profile/Profile.module.css
+++ b/packages/app/src/pages/profile/Profile.module.css
@@ -1,0 +1,4 @@
+.profile__center {
+  width: 100%;
+  height: 100%;
+}

--- a/packages/app/src/pages/profile/index.tsx
+++ b/packages/app/src/pages/profile/index.tsx
@@ -36,7 +36,7 @@ import { AuthLayout } from '@/components/layouts'
 import { getTranslation, logout } from '@/utils'
 import { baseGetServerSideProps } from '@/utils/next'
 
-import classes from './profile.module.css'
+import classes from './Profile.module.css'
 
 function ProfileView(): JSX.Element {
   const { t } = useTranslation()

--- a/packages/app/src/pages/profile/index.tsx
+++ b/packages/app/src/pages/profile/index.tsx
@@ -36,6 +36,8 @@ import { AuthLayout } from '@/components/layouts'
 import { getTranslation, logout } from '@/utils'
 import { baseGetServerSideProps } from '@/utils/next'
 
+import classes from './profile.module.css'
+
 function ProfileView(): JSX.Element {
   const { t } = useTranslation()
 
@@ -100,7 +102,7 @@ function ProfileView(): JSX.Element {
   }
 
   return (
-    <Center w="100%" h="100%">
+    <Center className={classes['profile__center']}>
       {t('profileView.userNotFound')}
     </Center>
   )

--- a/packages/app/src/pages/set-password/SetPassword.module.css
+++ b/packages/app/src/pages/set-password/SetPassword.module.css
@@ -1,0 +1,12 @@
+.setPassword__container {
+  margin-top: var(--mantine-spacing-xl);
+  margin-bottom: var(--mantine-spacing-xl);
+}
+
+.setPassword__paper {
+  padding: var(--mantine-spacing-lg);
+  margin-top: var(--mantine-spacing-md);
+  width: 400px;
+  height: 270px;
+  border-radius: var(--mantine-radius-sm);
+}

--- a/packages/app/src/pages/set-password/SetPassword.module.css
+++ b/packages/app/src/pages/set-password/SetPassword.module.css
@@ -1,6 +1,8 @@
 .setPassword__container {
   margin-top: var(--mantine-spacing-xl);
   margin-bottom: var(--mantine-spacing-xl);
+  width: 450px;
+  height: 450px;
 }
 
 .setPassword__paper {
@@ -9,4 +11,5 @@
   width: 400px;
   height: 270px;
   border-radius: var(--mantine-radius-sm);
+  box-shadow: var(--mantine-shadow-sm);
 }

--- a/packages/app/src/pages/set-password/index.tsx
+++ b/packages/app/src/pages/set-password/index.tsx
@@ -32,6 +32,8 @@ import { PublicLayout } from '@/components/layouts'
 import { getTranslation } from '@/utils'
 import { baseGetServerSideProps } from '@/utils/next'
 
+import classes from './SetPassword.module.css'
+
 function SetPasswordView(): JSX.Element {
   const { t } = useTranslation()
 
@@ -53,14 +55,14 @@ function SetPasswordView(): JSX.Element {
   }
 
   return (
-    <Container size={450} my="xl">
+    <Container size={450} className={classes['setPassword__container']}>
       {!showSuccessMessage && (
         <Title ta="center" order={2} fw="bold">
           {t('setPasswordView.title')}
         </Title>
       )}
 
-      <Paper shadow="sm" p="lg" mt="md" w={400} h={270} radius="sm">
+      <Paper shadow="sm" className={classes['setPassword__paper']}>
         {!showSuccessMessage && (
           <SetPasswordForm handleSetPassword={handleSetPassword} />
         )}

--- a/packages/app/src/pages/set-password/index.tsx
+++ b/packages/app/src/pages/set-password/index.tsx
@@ -55,14 +55,14 @@ function SetPasswordView(): JSX.Element {
   }
 
   return (
-    <Container size={450} className={classes['setPassword__container']}>
+    <Container className={classes['setPassword__container']}>
       {!showSuccessMessage && (
         <Title ta="center" order={2} fw="bold">
           {t('setPasswordView.title')}
         </Title>
       )}
 
-      <Paper shadow="sm" className={classes['setPassword__paper']}>
+      <Paper className={classes['setPassword__paper']}>
         {!showSuccessMessage && (
           <SetPasswordForm handleSetPassword={handleSetPassword} />
         )}

--- a/packages/app/src/pages/users/[id].tsx
+++ b/packages/app/src/pages/users/[id].tsx
@@ -100,12 +100,7 @@ function UpdateUserView(): JSX.Element {
         </Flex>
       </Title>
 
-      <Card
-        shadow="sm"
-        radius="sm"
-        withBorder
-        className={classes['userDetailCard']}
-      >
+      <Card withBorder className={classes['userDetailCard']}>
         <UserForm
           ssoProvider={ssoProvider}
           title={t('addUpdateUserView.form.userDataHeading')}

--- a/packages/app/src/pages/users/add/AddUserView.module.css
+++ b/packages/app/src/pages/users/add/AddUserView.module.css
@@ -17,9 +17,11 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.add-user-view {
+.add-user-view__card {
   padding: var(--mantine-spacing-lg);
   max-width: 81.25rem;
+  box-shadow: var(--mantine-shadow-sm);
+  border-radius: var(--mantine-radius-sm);
 
   @mixin dark {
     background-color: var(--mantine-color-dark-7);

--- a/packages/app/src/pages/users/add/index.tsx
+++ b/packages/app/src/pages/users/add/index.tsx
@@ -74,12 +74,7 @@ function AddUserView(): JSX.Element {
         </Flex>
       </Title>
 
-      <Card
-        shadow="sm"
-        radius="sm"
-        withBorder
-        className={classes['add-user-view']}
-      >
+      <Card withBorder className={classes['add-user-view__card']}>
         <UserForm
           title={t('addUpdateUserView.form.userDataHeading')}
           roles={roles}

--- a/packages/app/src/pages/users/users.module.css
+++ b/packages/app/src/pages/users/users.module.css
@@ -62,6 +62,8 @@
 .userDetailCard {
   padding: var(--mantine-spacing-lg);
   max-width: 81.25rem;
+  box-shadow: var(--mantine-shadow-sm);
+  radius: var(--mantine-radius-sm);
 
   @mixin dark {
     background-color: var(--mantine-color-dark-7);

--- a/packages/docs/pages/styleguide/styling-conventions.mdx
+++ b/packages/docs/pages/styleguide/styling-conventions.mdx
@@ -6,8 +6,7 @@ To maintain consistency across the codebase, we adhere to the following conventi
 
 This is the styling hierarchy for component styles, staying as close to native Mantine functionality as possible.
 
-[Component Style Props](https://mantine.dev/styles/style-props/) >
-[Styles API](https://mantine.dev/styles/styles-api/) >[ CSS modules](https://mantine.dev/styles/css-modules/)
+[CSS modules](https://mantine.dev/styles/css-modules/) > [Component Style Props](https://mantine.dev/styles/style-props/) > [Styles API](https://mantine.dev/styles/styles-api/)
 
 ## Colors
 

--- a/packages/docs/pages/styleguide/styling-conventions.mdx
+++ b/packages/docs/pages/styleguide/styling-conventions.mdx
@@ -8,6 +8,10 @@ This is the styling hierarchy for component styles, staying as close to native M
 
 [CSS modules](https://mantine.dev/styles/css-modules/) > [Component Style Props](https://mantine.dev/styles/style-props/) > [Styles API](https://mantine.dev/styles/styles-api/)
 
+### Naming of CSS classes
+
+We follow the [BEM conventions](https://getbem.com/introduction/) to ensure a consistent approach when naming the classes.
+
 ## Colors
 
 Colors should never be hardcoded anywhere in the codebase except for the Mantine theme config. Only colors from the

--- a/packages/lib/src/components/Contact/components/ContactForm.module.css
+++ b/packages/lib/src/components/Contact/components/ContactForm.module.css
@@ -1,0 +1,44 @@
+.contact-form__container {
+  padding: 0;
+  margin: 0;
+}
+
+.contact-form__card {
+  padding: var(--mantine-spacing-lg);
+}
+
+.contact-form__title {
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.contact-form__error-box {
+  margin-top: -1.5rem;
+  height: 0.8rem;
+}
+
+.contact-form__error-text {
+  margin-left: 5;
+  font-size: var(--mantine-font-size-xs);
+  color: red;
+}
+
+.contact-form__error-box-message {
+  margin-top: -0.6em;
+  height: 0.8rem;
+}
+
+.contact-from__text-input {
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.contact-form__stack {
+  margin-top: var(--mantine-spacing-md);
+}
+
+.contact-form__text-area {
+  min-width: 45%;
+}
+
+.contact-form__group {
+  margin-top: var(--mantine-spacing-md);
+}

--- a/packages/lib/src/components/Contact/components/ContactForm.module.css
+++ b/packages/lib/src/components/Contact/components/ContactForm.module.css
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .contact-form__container {
   padding: 0;
   margin: 0;
@@ -5,6 +24,8 @@
 
 .contact-form__card {
   padding: var(--mantine-spacing-lg);
+  box-shadow: var(--mantine-shadow-sm);
+  border-radius: var(--mantine-radius-md);
 }
 
 .contact-form__title {
@@ -29,6 +50,7 @@
 
 .contact-from__text-input {
   margin-bottom: var(--mantine-spacing-md);
+  border-radius: var(--mantine-radius-md);
 }
 
 .contact-form__stack {

--- a/packages/lib/src/components/Contact/components/ContactForm.tsx
+++ b/packages/lib/src/components/Contact/components/ContactForm.tsx
@@ -46,13 +46,7 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
   const { t } = useTranslation()
 
   return (
-    <Card
-      shadow="sm"
-      radius="md"
-      withBorder
-      role="form"
-      className={classes['contact-form__card']}
-    >
+    <Card withBorder role="form" className={classes['contact-form__card']}>
       <Title order={3} className={classes['contact-form__title']}>
         {t('contactView.contactForm.title')}
       </Title>
@@ -71,7 +65,6 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
                     label={t('contactView.contactForm.form.email')}
                     withAsterisk
                     size="sm"
-                    radius="md"
                   />
                 )}
               />
@@ -97,7 +90,6 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
                     className={classes['contact-from__text-input']}
                     label={t('contactView.contactForm.form.name')}
                     size="sm"
-                    radius="md"
                     withAsterisk
                   />
                 )}
@@ -127,7 +119,6 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
                   className={classes['contact-from__text-input']}
                   label={t('contactView.contactForm.form.subject')}
                   size="sm"
-                  radius="md"
                   variant="filled"
                   withAsterisk
                 />

--- a/packages/lib/src/components/Contact/components/ContactForm.tsx
+++ b/packages/lib/src/components/Contact/components/ContactForm.tsx
@@ -35,6 +35,8 @@ import { IconSend } from '@tabler/icons-react'
 import { useTranslation } from 'next-i18next'
 import { Control, Controller, FormState } from 'react-hook-form'
 
+import classes from './ContactForm.module.css'
+
 type Props = {
   control: Control<ContactFormType>
   formState: FormState<ContactFormType>
@@ -44,14 +46,20 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
   const { t } = useTranslation()
 
   return (
-    <Card shadow="sm" p="lg" radius="md" withBorder role="form">
-      <Title order={3} mb="md">
+    <Card
+      shadow="sm"
+      radius="md"
+      withBorder
+      role="form"
+      className={classes['contact-form__card']}
+    >
+      <Title order={3} className={classes['contact-form__title']}>
         {t('contactView.contactForm.title')}
       </Title>
 
       <Grid gutter={30}>
         <Grid.Col span={{ md: 6 }}>
-          <Container p={0} m={0}>
+          <Container className={classes['contact-form__container']}>
             <Stack>
               <Controller
                 name="mailAddress"
@@ -59,7 +67,7 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
                 render={({ field }) => (
                   <TextInput
                     {...field}
-                    mb="md"
+                    className={classes['contact-from__text-input']}
                     label={t('contactView.contactForm.form.email')}
                     withAsterisk
                     size="sm"
@@ -68,9 +76,9 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
                 )}
               />
 
-              <Box mt="-1.5rem" h="0.8rem">
+              <Box className={classes['contact-form__error-box']}>
                 {formState.errors.mailAddress && (
-                  <Text ml={5} fz="xs" color="red">
+                  <Text className={classes['contact-form__error-text']}>
                     {formState.errors.mailAddress?.message
                       ? String(t(formState.errors.mailAddress.message))
                       : null}
@@ -79,14 +87,14 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
               </Box>
             </Stack>
 
-            <Stack mt="md">
+            <Stack className={classes['contact-form__stack']}>
               <Controller
                 name="name"
                 control={control}
                 render={({ field }) => (
                   <TextInput
                     {...field}
-                    mb="md"
+                    className={classes['contact-from__text-input']}
                     label={t('contactView.contactForm.form.name')}
                     size="sm"
                     radius="md"
@@ -95,9 +103,9 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
                 )}
               />
 
-              <Box mt="-1.5rem" h="0.8rem">
+              <Box className={classes['contact-form__error-box']}>
                 {formState.errors.name && (
-                  <Text ml={5} fz="xs" color="red">
+                  <Text className={classes['contact-form__error-text']}>
                     {formState.errors.name?.message
                       ? String(t(formState.errors.name.message))
                       : null}
@@ -116,7 +124,7 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
               render={({ field }) => (
                 <TextInput
                   {...field}
-                  mb="md"
+                  className={classes['contact-from__text-input']}
                   label={t('contactView.contactForm.form.subject')}
                   size="sm"
                   radius="md"
@@ -126,9 +134,9 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
               )}
             />
 
-            <Box mt="-1.5rem" h="0.8rem">
+            <Box className={classes['contact-form__error-box']}>
               {formState.errors.subject && (
-                <Text ml={5} fz="xs" color="red">
+                <Text className={classes['contact-form__error-text']}>
                   {formState.errors.subject?.message
                     ? String(t(formState.errors.subject.message))
                     : null}
@@ -137,7 +145,7 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
             </Box>
           </Stack>
 
-          <Stack mt="md">
+          <Stack className={classes['contact-form__stack']}>
             <Controller
               name="message"
               control={control}
@@ -151,15 +159,15 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
                   withAsterisk
                   minRows={8}
                   maxRows={15}
-                  miw="45%"
                   variant="filled"
+                  className={classes['contact-form__text-area']}
                 />
               )}
             />
 
-            <Box mt="-0.6em" h="0.8rem">
+            <Box className={classes['contact-form__error-box-message']}>
               {formState.errors.message && (
-                <Text ml={5} fz="xs" color="red">
+                <Text className={classes['contact-form__error-text']}>
                   {formState.errors.message?.message
                     ? String(t(formState.errors.message?.message))
                     : null}
@@ -170,7 +178,7 @@ export function ContactForm({ formState, control }: Props): JSX.Element {
         </Grid.Col>
       </Grid>
 
-      <Group justify="right" mt="md">
+      <Group justify="right" className={classes['contact-form__group']}>
         <Button type="submit" leftSection={<IconSend size={20} />}>
           {t('contactView.contactForm.form.sendMessage')}
         </Button>

--- a/packages/lib/src/components/Contact/components/ContactPersonCard.module.css
+++ b/packages/lib/src/components/Contact/components/ContactPersonCard.module.css
@@ -1,10 +1,32 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .contact-person-card__card {
-  paddig: var(--mantine-spacing-lg);
+  padding: var(--mantine-spacing-lg);
+  box-shadow: var(--mantine-shadow-sm);
+  border-radius: var(--mantine-radius-md);
 }
 
 .contact-person-card__avatar {
   margin-top: var(--mantine-spacing-xs);
-  color: indigo;
+
+  border-radius: var(--mantine-radius-xl);
 }
 
 .contact-person-card__title {
@@ -14,4 +36,13 @@
 
 .contact-person-card__group {
   margin-top: var(--mantine-spacing-xl);
+}
+
+.contact-person-card__theme-icon--radius {
+  border-radius: var(--mantine-radius-md);
+}
+
+.contact-person-card__icon--size {
+  width: 15px;
+  height: 15px;
 }

--- a/packages/lib/src/components/Contact/components/ContactPersonCard.module.css
+++ b/packages/lib/src/components/Contact/components/ContactPersonCard.module.css
@@ -1,0 +1,17 @@
+.contact-person-card__card {
+  paddig: var(--mantine-spacing-lg);
+}
+
+.contact-person-card__avatar {
+  margin-top: var(--mantine-spacing-xs);
+  color: indigo;
+}
+
+.contact-person-card__title {
+  margin-top: var(--mantine-spacing-sm);
+  margin-bottom: var(--mantine-spacing-sm);
+}
+
+.contact-person-card__group {
+  margin-top: var(--mantine-spacing-xl);
+}

--- a/packages/lib/src/components/Contact/components/ContactPersonCard.tsx
+++ b/packages/lib/src/components/Contact/components/ContactPersonCard.tsx
@@ -43,8 +43,6 @@ export function ContactPersonCard(): JSX.Element {
 
   return (
     <Card
-      shadow="sm"
-      radius="md"
       withBorder
       role="complementary"
       className={classes['contact-person-card__card']}
@@ -59,7 +57,8 @@ export function ContactPersonCard(): JSX.Element {
 
         <Avatar
           size="xl"
-          radius="xl"
+          // color gets not applied when outsourced to module.css
+          color="var(--mantine-color-blue-6)"
           src={null}
           alt={String(t('contactView.contactPersonCard.avatar.alt'))}
           className={classes['contact-person-card__avatar']}
@@ -70,25 +69,44 @@ export function ContactPersonCard(): JSX.Element {
         </Title>
 
         <Flex direction="column" align="flex-start" gap="sm">
-          <Group gap="xl" aria-label="Contact info">
-            <ThemeIcon radius="md">
-              <IconPhoneCall size={16} />
+          <Group
+            gap="xl"
+            aria-label={
+              t(
+                'contactView.contactPersonCard.contactPerson.ariaLabel',
+              ) as string
+            }
+          >
+            <ThemeIcon
+              className={classes['contact-person-card__theme-icon--radius']}
+            >
+              <IconPhoneCall
+                className={classes['contact-person-card__icon--size']}
+              />
             </ThemeIcon>
 
             <Text>555 - 5555 5555</Text>
           </Group>
 
           <Group gap="xl" aria-label="Contact info">
-            <ThemeIcon radius="md">
-              <IconMail size={16} />
+            <ThemeIcon
+              className={classes['contact-person-card__theme-icon--radius']}
+            >
+              <IconMail
+                className={classes['contact-person-card__icon--size']}
+              />
             </ThemeIcon>
 
             <Text>test@email.de</Text>
           </Group>
 
           <Group gap="xl" aria-label="Contact info">
-            <ThemeIcon radius="md">
-              <IconLocation size={16} />
+            <ThemeIcon
+              className={classes['contact-person-card__theme-icon--radius']}
+            >
+              <IconLocation
+                className={classes['contact-person-card__icon--size']}
+              />
             </ThemeIcon>
 
             <Text>Teststreet 1, 12345 Testcity</Text>
@@ -99,16 +117,34 @@ export function ContactPersonCard(): JSX.Element {
           className={classes['contact-person-card__group']}
           aria-label="Contact info"
         >
-          <ThemeIcon variant="light" radius="md">
-            <IconBrandLinkedin size={15} aria-label="Social icon" />
+          <ThemeIcon
+            variant="light"
+            className={classes['contact-person-card__theme-icon--radius']}
+          >
+            <IconBrandLinkedin
+              className={classes['contact-person-card__icon--size']}
+              aria-label="Social icon"
+            />
           </ThemeIcon>
 
-          <ThemeIcon variant="light" radius="md">
-            <IconBrandFacebook size={15} aria-label="Social icon" />
+          <ThemeIcon
+            variant="light"
+            className={classes['contact-person-card__theme-icon--radius']}
+          >
+            <IconBrandFacebook
+              className={classes['contact-person-card__icon--size']}
+              aria-label="Social icon"
+            />
           </ThemeIcon>
 
-          <ThemeIcon variant="light" radius="md">
-            <IconBrandInstagram size={15} aria-label="Social icon" />
+          <ThemeIcon
+            variant="light"
+            className={classes['contact-person-card__theme-icon--radius']}
+          >
+            <IconBrandInstagram
+              className={classes['contact-person-card__icon--size']}
+              aria-label="Social icon"
+            />
           </ThemeIcon>
         </Group>
       </Flex>

--- a/packages/lib/src/components/Contact/components/ContactPersonCard.tsx
+++ b/packages/lib/src/components/Contact/components/ContactPersonCard.tsx
@@ -36,11 +36,19 @@ import {
 } from '@tabler/icons-react'
 import { useTranslation } from 'next-i18next'
 
+import classes from './ContactPersonCard.module.css'
+
 export function ContactPersonCard(): JSX.Element {
   const { t } = useTranslation()
 
   return (
-    <Card shadow="sm" p="lg" radius="md" withBorder role="complementary">
+    <Card
+      shadow="sm"
+      radius="md"
+      withBorder
+      role="complementary"
+      className={classes['contact-person-card__card']}
+    >
       <Flex
         direction={{ base: 'column', sm: 'column' }}
         gap={{ base: 'sm', sm: 'md' }}
@@ -52,13 +60,12 @@ export function ContactPersonCard(): JSX.Element {
         <Avatar
           size="xl"
           radius="xl"
-          mt="xs"
           src={null}
           alt={String(t('contactView.contactPersonCard.avatar.alt'))}
-          color="indigo"
+          className={classes['contact-person-card__avatar']}
         />
 
-        <Title order={5} mb="sm" mt="sm">
+        <Title order={5} className={classes['contact-person-card__title']}>
           Firstname Lastname
         </Title>
 
@@ -88,7 +95,10 @@ export function ContactPersonCard(): JSX.Element {
           </Group>
         </Flex>
 
-        <Group mt="xl" aria-label="Contact info">
+        <Group
+          className={classes['contact-person-card__group']}
+          aria-label="Contact info"
+        >
           <ThemeIcon variant="light" radius="md">
             <IconBrandLinkedin size={15} aria-label="Social icon" />
           </ThemeIcon>

--- a/packages/lib/src/components/DeleteDialog/DeleteDialog.module.css
+++ b/packages/lib/src/components/DeleteDialog/DeleteDialog.module.css
@@ -1,0 +1,11 @@
+.delete-dialog__title {
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.delete-dialog__text {
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.delete-dialog__button {
+  margin-top: var(--mantine-spacing-md);
+}

--- a/packages/lib/src/components/DeleteDialog/DeleteDialog.module.css
+++ b/packages/lib/src/components/DeleteDialog/DeleteDialog.module.css
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .delete-dialog__title {
   margin-bottom: var(--mantine-spacing-md);
 }

--- a/packages/lib/src/components/DeleteDialog/DeleteDialog.tsx
+++ b/packages/lib/src/components/DeleteDialog/DeleteDialog.tsx
@@ -20,6 +20,8 @@
 import { Button, Flex, Modal, Text, Title } from '@mantine/core'
 import { useTranslation } from 'next-i18next'
 
+import classes from './DeleteDialog.module.css'
+
 type Props = {
   deleteFunction: () => void
   title: string
@@ -46,18 +48,27 @@ export function DeleteDialog({
       padding="lg"
       centered
     >
-      <Title order={4} mb="md">
+      <Title order={4} className={classes['delete-dialog__title']}>
         {title}
       </Title>
 
-      <Text mb="md">{text}</Text>
+      <Text className={classes['delete-dialog__text']}>{text}</Text>
 
       <Flex justify="space-around" gap="lg">
-        <Button fullWidth mt="md" onClick={deleteFunction}>
+        <Button
+          fullWidth
+          className={classes['delete-dialog__button']}
+          onClick={deleteFunction}
+        >
           {t('actions.delete')}
         </Button>
 
-        <Button variant="subtle" fullWidth mt="md" onClick={onClose}>
+        <Button
+          variant="subtle"
+          fullWidth
+          className={classes['delete-dialog__button']}
+          onClick={onClose}
+        >
           {t('actions.cancel')}
         </Button>
       </Flex>

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -23,23 +23,34 @@
 }
 
 .feedback-widget__action-icon {
-  border-radius: '20px';
+  border-radius: 20px;
+  width: 70px;
+  height: 70px;
 }
 
 .feedback-widget__theme-icon {
   border: none;
+  width: 60px;
+  height: 60px;
 }
 
 .feedback-widget__dialog--display {
   display: none;
 }
 
+.feedback-widget__dialog {
+  width: 390px;
+  border-radius: var(--mantine-radius-md);
+}
+
 .feedback-widget__title {
   margin-bottom: var(--mantine-spacing-sm);
   font-weight: 500;
+  text-align: center;
+  font-size: var(--mantine-font-size-md);
 }
 
-.feedback-widget_group {
+.feedback-widget__group {
   margin-bottom: var(--mantine-spacing-md);
 }
 
@@ -59,4 +70,23 @@
   margin-left: 5px;
   font-size: var(--mantine-font-size-xs);
   color: red;
+}
+
+.feedback-widget__loading-spinner--container {
+  height: 100px;
+}
+
+.feedback-widget__icon--check {
+  border: none;
+  width: 60px;
+  height: 60px;
+  stroke: 1.5;
+}
+
+.feedback-widget__icon--x {
+  border: none;
+  width: 60px;
+  height: 60px;
+  stroke: 1.5;
+  color: var(--mantine-color-red-6);
 }

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -33,3 +33,30 @@
 .feedback-widget__dialog--display {
   display: none;
 }
+
+.feedback-widget__title {
+  margin-bottom: var(--mantine-spacing-sm);
+  font-weight: 500;
+}
+
+.feedback-widget_group {
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.feedback-widget__button {
+  padding: 5px;
+  width: 110px;
+  height: 32px;
+}
+
+.feedback-widget__error-box {
+  height: 0.8rem;
+  margin-top: -0.8rem;
+  margin-bottom: 0.6em;
+}
+
+.feedback-widget__error-text {
+  margin-left: 5px;
+  font-size: var(--mantine-font-size-xs);
+  color: red;
+}

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -40,7 +40,6 @@ import {
   Tooltip,
   Transition,
   UnstyledButton,
-  useMantineTheme,
 } from '@mantine/core'
 import { useDisclosure } from '@mantine/hooks'
 import {
@@ -85,8 +84,6 @@ export function FeedbackWidget({
   feedbackSending,
   createNotification,
 }: Props): JSX.Element {
-  const theme = useMantineTheme()
-
   const { t } = useTranslation()
 
   const router = useRouter()
@@ -232,7 +229,7 @@ export function FeedbackWidget({
           position: 'fixed',
           bottom: 80,
           right: 25,
-          zIndex: '20',
+          zIndex: 20,
         }}
         onClick={toggle}
       >
@@ -245,23 +242,16 @@ export function FeedbackWidget({
         onClose={() => {
           onCloseWidget()
         }}
-        radius="md"
-        w="390px"
         h={openInput ? 'auto' : '180px'}
         position={{ bottom: 100, right: 80 }}
         className={
           isCapturingScreenshot
             ? classes['feedback-widget__dialog--display']
-            : ''
+            : classes['feedback-widget__dialog']
         }
       >
         {!showSuccessMessage || !showErrorMessage ? (
-          <Title
-            order={4}
-            ta="center"
-            size="sm"
-            className={classes['feedback-widget__title']}
-          >
+          <Title className={classes['feedback-widget__title']}>
             {t('feedbackWidget.title')}
           </Title>
         ) : null}
@@ -274,7 +264,6 @@ export function FeedbackWidget({
                 <Stack key={key}>
                   <ActionIcon
                     variant="filled"
-                    size={70}
                     className={classes['feedback-widget__action-icon']}
                     onClick={() => {
                       setOpenInput(OpenInput[inputKey])
@@ -305,7 +294,11 @@ export function FeedbackWidget({
             <div style={styles}>
               <Box>
                 {isLoading ? (
-                  <Box h={100}>
+                  <Box
+                    className={
+                      classes['feedback-widget__loading-spinner--container']
+                    }
+                  >
                     <LoadingSpinner show size="lg" />
                   </Box>
                 ) : null}
@@ -317,15 +310,14 @@ export function FeedbackWidget({
                         <ThemeIcon
                           variant="outline"
                           className={classes['feedback-widget__theme-icon']}
-                          size={60}
                         >
-                          <IconCircleCheck size={60} stroke={1.5} />
+                          <IconCircleCheck
+                            className={classes['feedback-widget__icon--check']}
+                          />
                         </ThemeIcon>
                       ) : (
                         <IconCircleX
-                          size={60}
-                          stroke={1.5}
-                          color={theme.colors.red[6]}
+                          className={classes['feedback-widget__icon--x']}
                         />
                       )}
                     </Center>
@@ -345,7 +337,7 @@ export function FeedbackWidget({
                     <Group
                       justify="apart"
                       gap="xs"
-                      className={classes['feedback-widget_group']}
+                      className={classes['feedback-widget__group']}
                     >
                       {Object.keys(OpenInput).map(key => {
                         const inputKey = key as keyof typeof OpenInput

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -256,7 +256,12 @@ export function FeedbackWidget({
         }
       >
         {!showSuccessMessage || !showErrorMessage ? (
-          <Title order={4} ta="center" size="sm" mb="sm" fw={500}>
+          <Title
+            order={4}
+            ta="center"
+            size="sm"
+            className={classes['feedback-widget__title']}
+          >
             {t('feedbackWidget.title')}
           </Title>
         ) : null}
@@ -337,16 +342,18 @@ export function FeedbackWidget({
 
                 {!isLoading && !showSuccessMessage && !showErrorMessage ? (
                   <Box>
-                    <Group justify="apart" gap="xs" mb="md">
+                    <Group
+                      justify="apart"
+                      gap="xs"
+                      className={classes['feedback-widget_group']}
+                    >
                       {Object.keys(OpenInput).map(key => {
                         const inputKey = key as keyof typeof OpenInput
 
                         return (
                           <Button
                             key={key}
-                            p="5px"
-                            w="110px"
-                            h="32px"
+                            className={classes['feedback-widget__button']}
                             variant={
                               openInput === OpenInput[inputKey]
                                 ? 'filled'
@@ -379,9 +386,11 @@ export function FeedbackWidget({
                         )}
                       />
 
-                      <Box h="0.8rem" mt="-0.8rem" mb="0.6em">
+                      <Box className={classes['feedback-widget__error-box']}>
                         {formState.errors.message && (
-                          <Text ml={5} fz="xs" c="red">
+                          <Text
+                            className={classes['feedback-widget__error-text']}
+                          >
                             {formState.errors.message?.message
                               ? String(t(formState.errors.message.message))
                               : null}

--- a/packages/lib/src/components/Footer/Footer.module.css
+++ b/packages/lib/src/components/Footer/Footer.module.css
@@ -17,7 +17,16 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.text {
+.footer__app-shell {
+  padding: var(--mantine-spacing-md);
+  z-index: 200;
+}
+
+.footer__flex {
+  margin-left: var(--mantine-spacing-xs);
+}
+
+.footer__text {
   @mixin dark {
     color: var(--mantine-color-gray-0);
   }

--- a/packages/lib/src/components/Footer/Footer.tsx
+++ b/packages/lib/src/components/Footer/Footer.tsx
@@ -34,7 +34,6 @@ export function Footer({ links }: Props): JSX.Element {
 
   return (
     <AppShellFooter className={classes['footer__app-shell']}>
-    <AppShellFooter p="md">
       <Flex
         justify={{ base: 'center', xs: 'space-between' }}
         direction="row"

--- a/packages/lib/src/components/Footer/Footer.tsx
+++ b/packages/lib/src/components/Footer/Footer.tsx
@@ -33,13 +33,19 @@ export function Footer({ links }: Props): JSX.Element {
   const { t } = useTranslation()
 
   return (
+    <AppShellFooter className={classes['footer__app-shell']}>
     <AppShellFooter p="md">
       <Flex
         justify={{ base: 'center', xs: 'space-between' }}
         direction="row"
         wrap="wrap"
       >
-        <Flex gap="xs" align="center" ml="xs" visibleFrom="sm">
+        <Flex
+          gap="xs"
+          align="center"
+          className={classes.footer__flex}
+          visibleFrom="sm"
+        >
           <IconCopyright size="16" />
 
           <Text> {t('footer.license')} </Text>
@@ -51,7 +57,7 @@ export function Footer({ links }: Props): JSX.Element {
               component={NextLink}
               key={link.label}
               href={link.to}
-              className={classes['text']}
+              className={classes.footer__text}
             >
               {t(link.label)}
             </Text>

--- a/packages/lib/src/components/Header/Header.module.css
+++ b/packages/lib/src/components/Header/Header.module.css
@@ -17,10 +17,18 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.appShellHeader {
+.header__app-shell {
   padding: var(--mantine-spacing-md);
+
+  @media (max-width: $mantine-breakpoint-sm) {
+    margin-left: 0;
+  }
 }
 
-.appShellHeader__content {
+.header__content {
   height: 100%;
+}
+
+.header__burger {
+  z-index: 200;
 }

--- a/packages/lib/src/components/Header/Header.tsx
+++ b/packages/lib/src/components/Header/Header.tsx
@@ -41,7 +41,7 @@ export function Header({ user, isOpen, handleOpenNav }: Props): JSX.Element {
   return (
     <AppShellHeader withBorder={false} className={classes['appShellHeader']}>
       <Flex
-        className={classes['appShellHeader__content']}
+        className={classes.header__content}
         justify="space-between"
         align="center"
       >
@@ -54,6 +54,7 @@ export function Header({ user, isOpen, handleOpenNav }: Props): JSX.Element {
           // not in CSS module because it's not applied there with CSS 'color' prop
           color={theme.colors.gray[5]}
           hiddenFrom="sm"
+          className={classes.header__burger}
         />
 
         <SearchBar />

--- a/packages/lib/src/components/Header/Header.tsx
+++ b/packages/lib/src/components/Header/Header.tsx
@@ -39,7 +39,7 @@ export function Header({ user, isOpen, handleOpenNav }: Props): JSX.Element {
   const theme = useMantineTheme()
 
   return (
-    <AppShellHeader withBorder={false} className={classes['appShellHeader']}>
+    <AppShellHeader withBorder={false} className={classes['header__app-shell']}>
       <Flex
         className={classes.header__content}
         justify="space-between"

--- a/packages/lib/src/components/Header/components/SearchBar/SearchBar.module.css
+++ b/packages/lib/src/components/Header/components/SearchBar/SearchBar.module.css
@@ -1,0 +1,8 @@
+.search-bar__text {
+  color: var(--mantine-color-gray-5);
+  font-size: var(--mantine-font-size-sm);
+}
+
+.search-bar__icon {
+  color: var(--mantine-color-gray-5);
+}

--- a/packages/lib/src/components/Header/components/SearchBar/SearchBar.tsx
+++ b/packages/lib/src/components/Header/components/SearchBar/SearchBar.tsx
@@ -17,15 +17,15 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Group, Text, UnstyledButton, useMantineTheme } from '@mantine/core'
+import { Group, Text, UnstyledButton } from '@mantine/core'
 import { openSpotlight } from '@mantine/spotlight'
 import { IconSearch } from '@tabler/icons-react'
 import { useTranslation } from 'next-i18next'
 
+import classes from './SearchBar.module.css'
+
 export function SearchBar(): JSX.Element {
   const { t } = useTranslation()
-
-  const theme = useMantineTheme()
 
   return (
     <UnstyledButton
@@ -35,9 +35,9 @@ export function SearchBar(): JSX.Element {
     >
       <Group justify="apart">
         <Group gap="sm">
-          <IconSearch size="16" color={theme.colors.gray[4]} />
+          <IconSearch size="16" className={classes['search-bar__icon']} />
 
-          <Text c={theme.colors.gray[5]} size="sm" role="searchbox">
+          <Text className={classes['search-bar__text']} role="searchbox">
             {t('header.spotlight.placeholder')}
           </Text>
         </Group>

--- a/packages/lib/src/components/Header/components/ThemeSelector/ThemeSelector.module.css
+++ b/packages/lib/src/components/Header/components/ThemeSelector/ThemeSelector.module.css
@@ -17,7 +17,7 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.group {
+.theme-selector__group {
   padding: 0.7rem 0 0.5rem 1rem;
   cursor: pointer;
   &:hover {
@@ -31,7 +31,10 @@
   }
 }
 
-.button {
+.theme-selector__button {
+  padding: 0;
+  background-color: transparent;
+
   @mixin dark {
     color: var(--mantine-color-gray-0);
   }
@@ -41,7 +44,7 @@
   }
 }
 
-.iconLight {
+.theme-selector__iconLight {
   @mixin dark {
     display: none;
   }
@@ -51,7 +54,7 @@
   }
 }
 
-.iconDark {
+.theme-selector__iconDark {
   @mixin light {
     display: none;
   }
@@ -59,4 +62,12 @@
   @mixin dark {
     display: block;
   }
+}
+
+.theme-selector__text {
+  font-size: var(--mantine-font-size-sm);
+}
+
+.theme-selector__popover-dropdown {
+  padding: 0;
 }

--- a/packages/lib/src/components/Header/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/lib/src/components/Header/components/ThemeSelector/ThemeSelector.tsx
@@ -56,19 +56,17 @@ export function ThemeSelector(): JSX.Element {
       <PopoverTarget>
         <Button
           aria-label="theme-selector"
-          p={0}
-          bg="transparent"
-          className={classes['button']}
+          className={classes['theme-selector__button']}
           leftSection={
             <>
               <IconSun
-                className={classes['iconLight']}
+                className={classes['theme-selector__iconLight']}
                 color={
                   hasSelectedLight ? theme.colors.blue[6] : theme.colors.gray[9]
                 }
               />
               <IconMoon
-                className={classes['iconDark']}
+                className={classes['theme-selector__iconDark']}
                 color={
                   hasSelectedDark ? theme.colors.blue[6] : theme.colors.gray[5]
                 }
@@ -78,17 +76,19 @@ export function ThemeSelector(): JSX.Element {
         />
       </PopoverTarget>
 
-      <PopoverDropdown p={0}>
+      <PopoverDropdown className={classes['theme-selector__popover-dropdown']}>
         <Group
           onClick={() => {
             setColorScheme('light')
             setSelectedLight(true)
           }}
-          className={classes['group']}
+          className={classes['theme-selector__group']}
         >
           <IconSun size={20} />
 
-          <Text size="sm">{t('header.themeToggle.lightMode')}</Text>
+          <Text className={classes['theme-selector__text']}>
+            {t('header.themeToggle.lightMode')}
+          </Text>
         </Group>
 
         <Group
@@ -96,11 +96,13 @@ export function ThemeSelector(): JSX.Element {
             setColorScheme('dark')
             setSelectedDark(true)
           }}
-          className={classes['group']}
+          className={classes['theme-selector__group']}
         >
           <IconMoon size={20} />
 
-          <Text size="sm">{t('header.themeToggle.darkMode')}</Text>
+          <Text className={classes['theme-selector__text']}>
+            {t('header.themeToggle.darkMode')}
+          </Text>
         </Group>
 
         <Group
@@ -109,11 +111,13 @@ export function ThemeSelector(): JSX.Element {
             setSelectedLight(false)
             setSelectedDark(false)
           }}
-          className={classes['group']}
+          className={classes['theme-selector__group']}
         >
           <IconDeviceLaptop size={20} />
 
-          <Text size="sm">{t('header.themeToggle.systemMode')}</Text>
+          <Text className={classes['theme-selector__text']}>
+            {t('header.themeToggle.systemMode')}
+          </Text>
         </Group>
       </PopoverDropdown>
     </Popover>

--- a/packages/lib/src/components/Header/components/UserMenu/UserMenu.module.css
+++ b/packages/lib/src/components/Header/components/UserMenu/UserMenu.module.css
@@ -17,7 +17,7 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.userMenuGroup {
+.user-menu__group {
   padding: var(--mantine-spacing-sm);
   cursor: pointer;
   border-radius: var(--mantine-radius-sm);
@@ -33,19 +33,21 @@
   }
 }
 
-.userMenuButton {
+.user-menu__button {
   display: block;
   width: 100%;
 }
 
-.userMenuBox {
+.user-menu__box {
   flex: 1;
 }
 
-.userMenuBox__name {
+.user_menu__box--name {
   font-weight: 500;
+  font-size: var(--mantine-font-size-sm);
 }
 
-.userMenuBox__mail {
+.user-menu__box--mail {
   color: var(--mantine-color-dimmed);
+  font-size: var(--mantine-font-size-xs);
 }

--- a/packages/lib/src/components/Header/components/UserMenu/UserMenu.tsx
+++ b/packages/lib/src/components/Header/components/UserMenu/UserMenu.tsx
@@ -36,22 +36,20 @@ export function UserMenu({ user }: Props): JSX.Element {
     <UnstyledButton
       component={NextLink}
       href="/profile"
-      className={classes['userMenuButton']}
+      className={classes['user-menu__button']}
       aria-label={t('header.profile.arialLabel') as string}
     >
-      <Group className={classes['userMenuGroup']} wrap="nowrap">
+      <Group className={classes['user-menu__group']} wrap="nowrap">
         <IconUser size="28" />
 
-        <Box className={classes['userMenuBox']}>
+        <Box className={classes['user-menu__box']}>
           <Flex align="center" justify="space-between">
-            <Text size="sm" className={classes['userMenuBox__name']}>
+            <Text className={classes['user_menu__box--name']}>
               {user.firstName} {user.lastName}
             </Text>
           </Flex>
 
-          <Text className={classes['userMenuBox__mail']} size="xs">
-            {user.email}
-          </Text>
+          <Text className={classes['user-menu__box--mail']}>{user.email}</Text>
         </Box>
 
         <IconChevronRight size={18} />

--- a/packages/lib/src/components/Home/Home.module.css
+++ b/packages/lib/src/components/Home/Home.module.css
@@ -17,6 +17,10 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.flex {
+.home__flex {
   height: 80vh;
+}
+
+.home__container {
+  width: 300px;
 }

--- a/packages/lib/src/components/Home/Home.tsx
+++ b/packages/lib/src/components/Home/Home.tsx
@@ -36,7 +36,7 @@ export function Home(): JSX.Element {
       gap="lg"
       align="center"
       justify="center"
-      className={classes['flex']}
+      className={classes.home__flex}
     >
       <Center my="lg">
         <Image
@@ -48,7 +48,7 @@ export function Home(): JSX.Element {
         />
       </Center>
 
-      <Container w={300}>
+      <Container className={classes.home__container}>
         <Stack>
           <Button
             onClick={() => openSpotlight()}
@@ -58,6 +58,7 @@ export function Home(): JSX.Element {
           >
             {t('homeView.action.search')}
           </Button>
+
           <Button
             onClick={() => router.push('/users')}
             variant="outline"
@@ -66,6 +67,7 @@ export function Home(): JSX.Element {
           >
             {t('homeView.action.users')}
           </Button>
+
           <Button
             onClick={() => router.push('/profile')}
             variant="outline"

--- a/packages/lib/src/components/LoadingSpinner/LoadingSpinner.module.css
+++ b/packages/lib/src/components/LoadingSpinner/LoadingSpinner.module.css
@@ -1,0 +1,6 @@
+.loading-spinner__container {
+  top: 50%;
+  left: 50%;
+  position: absolute;
+  transform: translate(-50%, -50%);
+}

--- a/packages/lib/src/components/LoadingSpinner/LoadingSpinner.module.css
+++ b/packages/lib/src/components/LoadingSpinner/LoadingSpinner.module.css
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .loading-spinner__container {
   top: 50%;
   left: 50%;

--- a/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
+++ b/packages/lib/src/components/LoadingSpinner/LoadingSpinner.tsx
@@ -20,6 +20,8 @@
 import { Container, Loader, LoaderProps } from '@mantine/core'
 import { useEffect, useState } from 'react'
 
+import classes from './LoadingSpinner.module.css'
+
 type Props = LoaderProps & { show: boolean; delay?: number }
 
 export function LoadingSpinner({
@@ -50,14 +52,7 @@ export function LoadingSpinner({
   }, [show, delay])
 
   return showSpinner ? (
-    <Container
-      style={{
-        top: '50%',
-        left: '50%',
-        position: 'absolute',
-        transform: 'translate(-50%, -50%)',
-      }}
-    >
+    <Container className={classes['loading-spinner__container']}>
       <Loader name="loader" size={size} {...props} />
     </Container>
   ) : null

--- a/packages/lib/src/components/LoginForm/LoginForm.module.css
+++ b/packages/lib/src/components/LoginForm/LoginForm.module.css
@@ -1,4 +1,23 @@
-.login-form__box {
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.login-form__container {
   width: 400px;
 }
 

--- a/packages/lib/src/components/LoginForm/LoginForm.module.css
+++ b/packages/lib/src/components/LoginForm/LoginForm.module.css
@@ -1,0 +1,34 @@
+.login-form__box {
+  width: 400px;
+}
+
+.login-form__input-label {
+  font-weight: var(--mantine-font-weight-bold);
+}
+
+.login-form__input-margin {
+  margin-top: var(--mantine-spacing-xs);
+}
+
+.login-form__error-box {
+  margin-top: 0.2rem;
+  height: 0.8rem;
+}
+
+.login-form__error-text {
+  margin-left: 5px;
+  font-size: var(--mantine-font-size-xs);
+  color: var(--mantine-color-red);
+}
+
+.login-form__button {
+  margin-top: var(--mantine-spacing-md);
+}
+
+.login-form__group {
+  margin-top: var(--mantine-spacing-md);
+}
+
+.login-form__center {
+  height: 100%;
+}

--- a/packages/lib/src/components/LoginForm/LoginForm.tsx
+++ b/packages/lib/src/components/LoginForm/LoginForm.tsx
@@ -74,7 +74,7 @@ export function LoginForm({
   }
 
   return (
-    <Box className={classes['login-form__box']}>
+    <Box className={classes['login-form__container']}>
       <Transition
         mounted={!isPasswordResetFormOpened && !isResetPasswordSent}
         transition="fade"

--- a/packages/lib/src/components/LoginForm/LoginForm.tsx
+++ b/packages/lib/src/components/LoginForm/LoginForm.tsx
@@ -40,6 +40,7 @@ import { Controller } from 'react-hook-form'
 
 import { useZodForm } from '../../hooks'
 import { ResetPasswordForm, ResetPasswordSuccessMessage } from './components'
+import classes from './LoginForm.module.css'
 
 type Props = {
   handleLogin: (name: string, pw: string) => void
@@ -73,7 +74,7 @@ export function LoginForm({
   }
 
   return (
-    <Box w={400}>
+    <Box className={classes['login-form__box']}>
       <Transition
         mounted={!isPasswordResetFormOpened && !isResetPasswordSent}
         transition="fade"
@@ -93,19 +94,17 @@ export function LoginForm({
                     placeholder={String(t('loginView.form.emailPlaceholder'))}
                     label={t('loginView.form.email')}
                     required
-                    styles={{
-                      label: {
-                        fontWeight: 'bold',
-                      },
+                    classNames={{
+                      label: classes['login-form__input-label'],
                     }}
                     withAsterisk
                   />
                 )}
               />
 
-              <Box mt="0.2rem" h="0.8rem">
+              <Box className={classes['login-form__error-box']}>
                 {formState.errors.email && (
-                  <Text ml={5} fz="xs" color="red">
+                  <Text className={classes['login-form__error-text']}>
                     {formState.errors.email?.message
                       ? String(t(formState.errors.email.message))
                       : null}
@@ -124,20 +123,18 @@ export function LoginForm({
                     )}
                     label={t('loginView.form.password')}
                     required
-                    styles={{
-                      label: {
-                        fontWeight: 'bold',
-                      },
+                    classNames={{
+                      label: classes['login-form__input-label'],
+                      root: classes['login-form__input-margin'],
                     }}
                     withAsterisk
-                    mt="xs"
                   />
                 )}
               />
 
-              <Box mt="0.2rem" h="0.8rem">
+              <Box className={classes['login-form__error-box']}>
                 {formState.errors.password && (
-                  <Text ml={5} fz="xs" color="red">
+                  <Text className={classes['login-form__error-text']}>
                     {formState.errors.password?.message
                       ? String(t(formState.errors.password.message))
                       : null}
@@ -145,7 +142,7 @@ export function LoginForm({
                 )}
               </Box>
 
-              <Group justify="apart" mt="md">
+              <Group justify="apart" className={classes['login-form__group']}>
                 <Anchor
                   size="xs"
                   fw="bold"
@@ -156,7 +153,11 @@ export function LoginForm({
                 </Anchor>
               </Group>
 
-              <Button type="submit" fullWidth mt="md">
+              <Button
+                type="submit"
+                fullWidth
+                className={classes['login-form__button']}
+              >
                 {t('loginView.form.submit')}
               </Button>
             </form>
@@ -182,7 +183,7 @@ export function LoginForm({
       </Transition>
 
       {isResettingPassword && (
-        <Center h="100%">
+        <Center className={classes['login-form__center']}>
           <Loader size="lg" name="loader" />
         </Center>
       )}

--- a/packages/lib/src/components/LoginForm/components/ResetPasswordForm.module.css
+++ b/packages/lib/src/components/LoginForm/components/ResetPasswordForm.module.css
@@ -1,0 +1,30 @@
+.reset-password-form__container {
+  padding: 0;
+  margin: 0;
+}
+
+.reset-password-form__text {
+  font-size: var(--mantine-font-size-sm);
+  font-weight: var(--mantine-font-weight-bold);
+  margin-top: var(--mantine-spacing-md);
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.reset-password-form__text-input {
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.reset-password-form__error-box {
+  margin-top: -0.6rem;
+  height: 0.8rem;
+}
+
+.reset-password-form__error-text {
+  margin-left: 5;
+  font-size: var(--mantine-font-size-xs);
+  color: red;
+}
+
+.reset-password-form__button {
+  margin-top: var(--mantine-spacing-lg);
+}

--- a/packages/lib/src/components/LoginForm/components/ResetPasswordForm.module.css
+++ b/packages/lib/src/components/LoginForm/components/ResetPasswordForm.module.css
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .reset-password-form__container {
   padding: 0;
   margin: 0;
@@ -12,6 +31,7 @@
 
 .reset-password-form__text-input {
   margin-bottom: var(--mantine-spacing-md);
+  radius: var(--mantine-radius-sm);
 }
 
 .reset-password-form__error-box {

--- a/packages/lib/src/components/LoginForm/components/ResetPasswordForm.tsx
+++ b/packages/lib/src/components/LoginForm/components/ResetPasswordForm.tsx
@@ -24,6 +24,7 @@ import { Dispatch, SetStateAction } from 'react'
 import { Controller } from 'react-hook-form'
 
 import { useZodForm } from '../../../hooks'
+import classes from './ResetPasswordForm.module.css'
 
 type Props = {
   setIsPasswordResetFormOpened: Dispatch<SetStateAction<boolean>>
@@ -47,9 +48,9 @@ export function ResetPasswordForm({
     handlePasswordReset(email)
   }
   return (
-    <Container p={0} m={0}>
+    <Container className={classes['reset-password-form__container']}>
       <form onSubmit={handleSubmit(onSubmit)}>
-        <Text size="sm" fw="bold" my="md">
+        <Text className={classes['reset-password-form__text']}>
           {t('loginView.resetPassword.form.description')}
         </Text>
 
@@ -65,14 +66,14 @@ export function ResetPasswordForm({
               label={String(t('loginView.resetPassword.form.label'))}
               withAsterisk
               radius="sm"
-              mb="md"
+              className={classes['reset-password-form__text-input']}
             />
           )}
         />
 
-        <Box mt="-0.6rem" h="0.8rem">
+        <Box className={classes['reset-password-form__error-box']}>
           {formState.errors.email && (
-            <Text ml={5} fz="xs" color="red">
+            <Text className={classes['reset-password-form__error-text']}>
               {formState.errors.email?.message
                 ? String(t(formState.errors.email.message))
                 : null}
@@ -81,12 +82,15 @@ export function ResetPasswordForm({
         </Box>
 
         <Group>
-          <Button mt="lg" type="submit">
+          <Button
+            className={classes['reset-password-form__button']}
+            type="submit"
+          >
             {t('loginView.resetPassword.form.submitButton')}
           </Button>
 
           <Button
-            mt="md"
+            className={classes['reset-password-form__button']}
             variant="light"
             onClick={() => {
               setIsPasswordResetFormOpened(false)

--- a/packages/lib/src/components/LoginForm/components/ResetPasswordForm.tsx
+++ b/packages/lib/src/components/LoginForm/components/ResetPasswordForm.tsx
@@ -65,7 +65,6 @@ export function ResetPasswordForm({
               )}
               label={String(t('loginView.resetPassword.form.label'))}
               withAsterisk
-              radius="sm"
               className={classes['reset-password-form__text-input']}
             />
           )}

--- a/packages/lib/src/components/LoginForm/components/ResetPasswordSuccessMessage.module.css
+++ b/packages/lib/src/components/LoginForm/components/ResetPasswordSuccessMessage.module.css
@@ -1,0 +1,10 @@
+.reset-password-success-message__center {
+  height: 200px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.reset-password-success-message__text {
+  font-size: var(--mantine-font-size-xs);
+  margin-top: var(--mantine-spacing-xs);
+}

--- a/packages/lib/src/components/LoginForm/components/ResetPasswordSuccessMessage.tsx
+++ b/packages/lib/src/components/LoginForm/components/ResetPasswordSuccessMessage.tsx
@@ -21,11 +21,13 @@ import { Center, Stack, Text, Title } from '@mantine/core'
 import { IconMailForward } from '@tabler/icons-react'
 import { useTranslation } from 'next-i18next'
 
+import classes from './ResetPasswordSuccessMessage.module.css'
+
 export function ResetPasswordSuccessMessage(): JSX.Element {
   const { t } = useTranslation()
 
   return (
-    <Center h={200} mx="auto">
+    <Center className={classes['reset-password-success-message__center']}>
       <Stack>
         <IconMailForward size={40} stroke={1} />
 
@@ -33,7 +35,7 @@ export function ResetPasswordSuccessMessage(): JSX.Element {
           {t('loginView.resetPassword.successMessage.title')}
         </Title>
 
-        <Text size="xs" mt="xs">
+        <Text className={classes['reset-password-success-message__text']}>
           {t('loginView.resetPassword.successMessage.description')}
         </Text>
       </Stack>

--- a/packages/lib/src/components/NavBar/components/NavLinks.module.css
+++ b/packages/lib/src/components/NavBar/components/NavLinks.module.css
@@ -17,11 +17,11 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.navlinkRoot {
+.nav-bar__navlink--root {
   border-radius: var(--mantine-radius-sm);
 }
 
-.navlinkLabel {
+.nav-bar__navlink--label {
   font-size: var(--mantine-font-size-sm);
   white-space: nowrap;
 }

--- a/packages/lib/src/components/NavBar/components/NavLinks.tsx
+++ b/packages/lib/src/components/NavBar/components/NavLinks.tsx
@@ -52,8 +52,8 @@ export function NavLinks({ links, userRights }: Props): JSX.Element {
             label={t(link.label)}
             active={link.to === router.pathname}
             classNames={{
-              root: classes['navlinkRoot'],
-              label: classes['navlinkLabel'],
+              root: classes['nav-bar__navlink--root'],
+              label: classes['nav-bar__navlink--label'],
             }}
           />
         ) : null,

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.module.css
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.module.css
@@ -17,10 +17,14 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.profile-data-card {
+.profile-data-card__card {
   padding: var(--mantine-spacing-lg);
 
   @mixin dark {
     background-color: var(--mantine-color-dark-7);
   }
+}
+
+.profile-data-card__tabs-panel {
+  padding-top: var(--mantine-spacing-lg);
 }

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.module.css
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.module.css
@@ -19,6 +19,8 @@
 
 .profile-data-card__card {
   padding: var(--mantine-spacing-lg);
+  box-shadow: var(--mantine-shadow-sm);
+  border-radius: var(--mantine-radius-sm);
 
   @mixin dark {
     background-color: var(--mantine-color-dark-7);

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
@@ -56,7 +56,7 @@ export function ProfileDataCard({
       shadow="sm"
       radius="sm"
       withBorder
-      className={classes['profile-data-card']}
+      className={classes['profile-data-card__card']}
     >
       <Tabs defaultValue="personalDataForm">
         <Tabs.List>
@@ -77,7 +77,10 @@ export function ProfileDataCard({
           )}
         </Tabs.List>
 
-        <Tabs.Panel value="personalDataForm" pt="lg">
+        <Tabs.Panel
+          value="personalDataForm"
+          className={classes['profile-data-card__tabs-panel']}
+        >
           <PersonalDataForm
             isSso={isSso}
             user={user}
@@ -87,7 +90,10 @@ export function ProfileDataCard({
         </Tabs.Panel>
 
         {isSso ? null : (
-          <Tabs.Panel value="passwordChange" pt="lg">
+          <Tabs.Panel
+            value="passwordChange"
+            className={classes['profile-data-card__tabs-panel']}
+          >
             <PasswordChangeForm
               handlePasswordUpdate={handlePasswordUpdate}
               isLoading={isUpdatingPassword}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
@@ -52,12 +52,7 @@ export function ProfileDataCard({
   const { t } = useTranslation()
 
   return (
-    <Card
-      shadow="sm"
-      radius="sm"
-      withBorder
-      className={classes['profile-data-card__card']}
-    >
+    <Card withBorder className={classes['profile-data-card__card']}>
       <Tabs defaultValue="personalDataForm">
         <Tabs.List>
           <Tabs.Tab

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.module.css
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.module.css
@@ -17,8 +17,26 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.stack {
+.password-change-form__stack {
+  min-width: 60%;
+  margin-bottom: var(--mantine-spacing-md);
+
   @media (max-width: 600px) {
     min-width: 100%;
   }
+}
+
+.password-change-form__error-box {
+  margin-top: -0.6rem;
+  height: 0.8rem;
+}
+
+.password-change-form__error-text {
+  margin-left: 5px;
+  font-size: var(--mantine-font-size-xs);
+  color: var(--mantine-color-red);
+}
+
+.password-change-form__button {
+  margin-top: var(--mantine-spacing-md);
 }

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
@@ -68,7 +68,6 @@ export function PasswordChangeForm({
                 label={t(
                   'profileView.dataCard.tabs.passwordChange.content.currentPassword',
                 )}
-                radius="sm"
                 withAsterisk
                 variant="filled"
               />
@@ -96,7 +95,6 @@ export function PasswordChangeForm({
                 label={t(
                   'profileView.dataCard.tabs.passwordChange.content.newPassword',
                 )}
-                radius="sm"
                 withAsterisk
                 variant="filled"
               />
@@ -124,7 +122,6 @@ export function PasswordChangeForm({
                 label={t(
                   'profileView.dataCard.tabs.passwordChange.content.confirmNewPassword',
                 )}
-                radius="sm"
                 withAsterisk
                 variant="filled"
               />

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
@@ -58,7 +58,7 @@ export function PasswordChangeForm({
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <Flex direction="column" align="flex-start">
-        <Stack miw="60%" mb="md" className={classes['stack']}>
+        <Stack className={classes['password-change-form__stack']}>
           <Controller
             name="verification"
             control={control}
@@ -75,9 +75,9 @@ export function PasswordChangeForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['password-change-form__error-box']}>
             {formState.errors.verification && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['password-change-form__error-text']}>
                 {formState.errors.verification?.message
                   ? String(t(formState.errors.verification.message))
                   : null}
@@ -86,7 +86,7 @@ export function PasswordChangeForm({
           </Box>
         </Stack>
 
-        <Stack miw="60%" mb="md" className={classes['stack']}>
+        <Stack className={classes['password-change-form__stack']}>
           <Controller
             name="password"
             control={control}
@@ -103,9 +103,9 @@ export function PasswordChangeForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['password-change-form__error-box']}>
             {formState.errors.password && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['password-change-form__error-text']}>
                 {formState.errors.password?.message
                   ? String(t(formState.errors.password.message))
                   : null}
@@ -114,7 +114,7 @@ export function PasswordChangeForm({
           </Box>
         </Stack>
 
-        <Stack miw="60%" mb="md" className={classes['stack']}>
+        <Stack className={classes['password-change-form__stack']}>
           <Controller
             name="confirmPassword"
             control={control}
@@ -131,9 +131,9 @@ export function PasswordChangeForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['password-change-form__error-box']}>
             {formState.errors.confirmPassword && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['password-change-form__error-text']}>
                 {formState.errors.confirmPassword?.message
                   ? String(t(formState.errors.confirmPassword.message))
                   : null}
@@ -142,7 +142,11 @@ export function PasswordChangeForm({
           </Box>
         </Stack>
 
-        <Button type="submit" mt="md" loading={isLoading}>
+        <Button
+          type="submit"
+          className={classes['password-change-form__button']}
+          loading={isLoading}
+        >
           {t('profileView.dataCard.tabs.passwordChange.content.savePassword')}
         </Button>
       </Flex>

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.module.css
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.module.css
@@ -41,3 +41,7 @@
 .personal-data-form__button {
   margin-top: var(--mantine-spacing-md);
 }
+
+.personal-data-form__flex--margin-top {
+  margin-top: var(--mantine-spacing-xs);
+}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.module.css
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.module.css
@@ -17,8 +17,27 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.select {
+.personal-data-form__select {
   @media (max-width: 600px) {
     min-width: 100%;
   }
+}
+
+.personal-data-form__stack {
+  min-width: 45%;
+}
+
+.personal-data-form__error-box {
+  margin-top: -0.6rem;
+  height: 0.8rem;
+}
+
+.personal-data-form__error-text {
+  margin-left: 5px;
+  font-size: var(--mantine-font-size-xs);
+  color: var(--mantine-color-red);
+}
+
+.personal-data-form__button {
+  margin-top: var(--mantine-spacing-md);
 }

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.tsx
@@ -114,7 +114,6 @@ export function PersonalDataForm({
                 )}
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -148,7 +147,6 @@ export function PersonalDataForm({
                 )}
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -169,7 +167,7 @@ export function PersonalDataForm({
         direction={{ base: 'column', sm: 'row' }}
         gap={{ base: 'sm', sm: 'md' }}
         justify={{ sm: 'space-between' }}
-        mt="xs"
+        className={classes['personal-data-form__flex--margin-top']}
       >
         <Stack className={classes['personal-data-form__stack']}>
           <Controller
@@ -184,7 +182,6 @@ export function PersonalDataForm({
                 label={t('profileView.dataCard.tabs.personalData.label.phone')}
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -215,7 +212,6 @@ export function PersonalDataForm({
                 label={t('profileView.dataCard.tabs.personalData.label.mobile')}
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -236,7 +232,7 @@ export function PersonalDataForm({
         direction={{ base: 'column', sm: 'row' }}
         gap={{ base: 'sm', sm: 'md' }}
         justify={{ sm: 'space-between' }}
-        mt="xs"
+        className={classes['personal-data-form__flex--margin-top']}
       >
         <Stack className={classes['personal-data-form__stack']}>
           <Controller
@@ -253,7 +249,6 @@ export function PersonalDataForm({
                 withAsterisk
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -276,7 +271,6 @@ export function PersonalDataForm({
             render={({ field }) => (
               <Select
                 {...field}
-                radius="sm"
                 label={t(
                   'profileView.dataCard.tabs.personalData.label.language',
                 )}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.tsx
@@ -36,6 +36,7 @@ import { useEffect } from 'react'
 import { Controller } from 'react-hook-form'
 
 import { useZodForm } from '../../../../../hooks'
+import classes from './PersonalDataForm.module.css'
 
 type Props = {
   isSso: boolean
@@ -95,7 +96,7 @@ export function PersonalDataForm({
         gap={{ base: 'xs', sm: 'md' }}
         justify={{ sm: 'space-between' }}
       >
-        <Stack miw="45%">
+        <Stack className={classes['personal-data-form__stack']}>
           <Controller
             name="firstName"
             control={control}
@@ -118,9 +119,9 @@ export function PersonalDataForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['personal-data-form__error-box']}>
             {formState.errors.firstName && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['personal-data-form__error-text']}>
                 {formState.errors.firstName?.message
                   ? String(t(formState.errors.firstName.message))
                   : null}
@@ -129,7 +130,7 @@ export function PersonalDataForm({
           </Box>
         </Stack>
 
-        <Stack miw="45%">
+        <Stack className={classes['personal-data-form__stack']}>
           <Controller
             name="lastName"
             control={control}
@@ -152,9 +153,9 @@ export function PersonalDataForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['personal-data-form__error-box']}>
             {formState.errors.lastName && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['personal-data-form__error-text']}>
                 {formState.errors.lastName?.message
                   ? String(t(formState.errors.lastName.message))
                   : null}
@@ -170,7 +171,7 @@ export function PersonalDataForm({
         justify={{ sm: 'space-between' }}
         mt="xs"
       >
-        <Stack miw="45%">
+        <Stack className={classes['personal-data-form__stack']}>
           <Controller
             name="phone"
             control={control}
@@ -188,9 +189,9 @@ export function PersonalDataForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['personal-data-form__error-box']}>
             {formState.errors.phone && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['personal-data-form__error-text']}>
                 {formState.errors.phone?.message
                   ? String(t(formState.errors.phone.message))
                   : null}
@@ -199,7 +200,7 @@ export function PersonalDataForm({
           </Box>
         </Stack>
 
-        <Stack miw="45%">
+        <Stack className={classes['personal-data-form__stack']}>
           <Controller
             name="mobile"
             control={control}
@@ -219,9 +220,9 @@ export function PersonalDataForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['personal-data-form__error-box']}>
             {formState.errors.mobile && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['personal-data-form__error-text']}>
                 {formState.errors.mobile?.message
                   ? String(t(formState.errors.mobile.message))
                   : null}
@@ -237,7 +238,7 @@ export function PersonalDataForm({
         justify={{ sm: 'space-between' }}
         mt="xs"
       >
-        <Stack miw="45%">
+        <Stack className={classes['personal-data-form__stack']}>
           <Controller
             name="email"
             control={control}
@@ -257,9 +258,9 @@ export function PersonalDataForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['personal-data-form__error-box']}>
             {formState.errors.email && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['personal-data-form__error-text']}>
                 {formState.errors.email?.message
                   ? String(t(formState.errors.email.message))
                   : null}
@@ -268,7 +269,7 @@ export function PersonalDataForm({
           </Box>
         </Stack>
 
-        <Stack miw="45%">
+        <Stack className={classes['personal-data-form__stack']}>
           <Controller
             name="locale"
             control={control}
@@ -290,9 +291,9 @@ export function PersonalDataForm({
             )}
           />
 
-          <Box mt="-0.6rem" h="0.8rem">
+          <Box className={classes['personal-data-form__error-box']}>
             {formState.errors.locale && (
-              <Text ml={5} fz="xs" color="red">
+              <Text className={classes['personal-data-form__error-text']}>
                 {formState.errors.locale?.message
                   ? String(t(formState.errors.locale.message))
                   : null}
@@ -302,7 +303,11 @@ export function PersonalDataForm({
         </Stack>
       </Flex>
 
-      <Button type="submit" mt="md" loading={isLoading}>
+      <Button
+        type="submit"
+        className={classes['personal-data-form__button']}
+        loading={isLoading}
+      >
         {t('profileView.dataCard.tabs.personalData.saveChanges')}
       </Button>
     </form>

--- a/packages/lib/src/components/Profile/components/ProfileOverviewCard.module.css
+++ b/packages/lib/src/components/Profile/components/ProfileOverviewCard.module.css
@@ -19,6 +19,8 @@
 
 .profile-overview-card {
   padding: var(--mantine-spacing-lg);
+  box-shadow: var(--mantine-shadow-sm);
+  border-radius: var(--mantine-radius-sm);
 
   @mixin dark {
     background-color: var(--mantine-color-dark-7);

--- a/packages/lib/src/components/Profile/components/ProfileOverviewCard.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileOverviewCard.tsx
@@ -44,12 +44,7 @@ export function ProfileOverviewCard({ user }: Props): JSX.Element {
   const isSso = Boolean(ssoProvider && ssoProvider !== UserSource.LOCAL)
 
   return (
-    <Card
-      shadow="sm"
-      radius="sm"
-      withBorder
-      className={classes['profile-overview-card']}
-    >
+    <Card withBorder className={classes['profile-overview-card']}>
       <Flex gap="md" justify="center" align="center" direction="column">
         <Indicator
           role="note"

--- a/packages/lib/src/components/Role/components/RoleForm.module.css
+++ b/packages/lib/src/components/Role/components/RoleForm.module.css
@@ -1,0 +1,28 @@
+.role-form__text-input--label {
+  font-weight: var(--mantine-font-weight-bold);
+}
+
+.role-form__error-box {
+  margin-top: -0.6rem;
+  height: 0.8rem;
+}
+
+.role-form__error-text {
+  margin-left: 5px;
+  font-size: var(--mantine-font-size-xs);
+  color: var(--mantine-color-red);
+}
+
+.role-form__divider--margin-xs {
+  margin-top: var(--mantine-spacing-xs);
+  margin-bottom: var(--mantine-spacing-xs);
+}
+
+.role-form__divider--margin-xl {
+  margin-top: var(--mantine-spacing-xl);
+  margin-bottom: var(--mantine-spacing-xl);
+}
+
+.role-form__button {
+  margin-top: var(--mantine-spacing-md);
+}

--- a/packages/lib/src/components/Role/components/RoleForm.module.css
+++ b/packages/lib/src/components/Role/components/RoleForm.module.css
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .role-form__text-input--label {
   font-weight: var(--mantine-font-weight-bold);
 }

--- a/packages/lib/src/components/Role/components/RoleForm.tsx
+++ b/packages/lib/src/components/Role/components/RoleForm.tsx
@@ -38,6 +38,8 @@ import { IconShieldCheck } from '@tabler/icons-react'
 import { useTranslation } from 'next-i18next'
 import { Control, Controller, FormState } from 'react-hook-form'
 
+import classes from './RoleForm.module.css'
+
 type Props = {
   rights: RightOutput[]
   toggleRight: (right: RightOutput) => void
@@ -76,10 +78,8 @@ export function RoleForm({
               label={t('rolesView.modal.name')}
               required
               variant="filled"
-              styles={{
-                label: {
-                  fontWeight: 'bold',
-                },
+              classNames={{
+                label: classes['role-form__text-input--label'],
               }}
               withAsterisk
               disabled={Boolean(role)}
@@ -87,9 +87,9 @@ export function RoleForm({
           )}
         />
 
-        <Box mt="-0.6rem" h="0.8rem">
+        <Box className={classes['role-form__error-box']}>
           {formState.errors.name && (
-            <Text ml={5} fz="xs" color="red">
+            <Text className={classes['role-form__error-text']}>
               {formState.errors.name?.message
                 ? String(t(formState.errors.name.message))
                 : null}
@@ -109,19 +109,17 @@ export function RoleForm({
               label={t('rolesView.modal.description')}
               required
               variant="filled"
-              styles={{
-                label: {
-                  fontWeight: 'bold',
-                },
+              classNames={{
+                label: classes['role-form__text-input--label'],
               }}
               withAsterisk
             />
           )}
         />
 
-        <Box mt="-0.6rem" h="0.8rem">
+        <Box className={classes['role-form__error-box']}>
           {formState.errors.description && (
-            <Text ml={5} fz="xs" color="red">
+            <Text className={classes['role-form__error-text']}>
               {formState.errors.description?.message
                 ? String(t(formState.errors.description.message))
                 : null}
@@ -130,7 +128,7 @@ export function RoleForm({
         </Box>
 
         <Divider
-          my="xs"
+          className={classes['role-form__divider--margin-xs']}
           label={
             <Flex align="start">
               <IconShieldCheck size={16} />
@@ -167,7 +165,7 @@ export function RoleForm({
         />
       </Flex>
 
-      <Divider my="xl" />
+      <Divider className={classes['role-form__divider--margin-xl']} />
 
       <Flex gap="lg" justify="start">
         <Controller
@@ -202,14 +200,19 @@ export function RoleForm({
       <Space h="lg" />
 
       <Flex justify="space-around" gap="lg">
-        <Button type="submit" fullWidth mt="md" loading={isLoading}>
+        <Button
+          type="submit"
+          fullWidth
+          className={classes['role-form__button']}
+          loading={isLoading}
+        >
           {role ? t('rolesView.modal.update') : t('rolesView.modal.submit')}
         </Button>
 
         <Button
           variant="subtle"
           fullWidth
-          mt="md"
+          className={classes['role-form__button']}
           onClick={() => {
             if (reset) reset()
             onClose()

--- a/packages/lib/src/components/SetPassword/SetPasswordForm.module.css
+++ b/packages/lib/src/components/SetPassword/SetPasswordForm.module.css
@@ -1,0 +1,26 @@
+.set-password-form__text-input--label {
+  font-weight: var(--mantine-font-weight-bold);
+}
+
+.set-password-form__error-box {
+  margin-top: -1.5rem;
+  height: 0.8rem;
+}
+
+.set-password-form__error-text {
+  margin-left: 5px;
+  font-size: var(--mantine-font-size-xs);
+  color: var(--mantine-color-red);
+}
+
+.set-password-form__button {
+  margin-top: var(--mantine-spacing-md);
+}
+
+.set-password-form__stack {
+  margin-top: var(--mantine-spacing-sm);
+}
+
+.set-password-form__text-input--root {
+  margin-bottom: var(--mantine-spacing-md);
+}

--- a/packages/lib/src/components/SetPassword/SetPasswordForm.module.css
+++ b/packages/lib/src/components/SetPassword/SetPasswordForm.module.css
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .set-password-form__text-input--label {
   font-weight: var(--mantine-font-weight-bold);
 }

--- a/packages/lib/src/components/SetPassword/SetPasswordForm.tsx
+++ b/packages/lib/src/components/SetPassword/SetPasswordForm.tsx
@@ -56,7 +56,6 @@ export function SetPasswordForm({ handleSetPassword }: Props): JSX.Element {
               placeholder={String(t('setPasswordView.form.newPassword'))}
               label={t('setPasswordView.form.newPassword')}
               withAsterisk
-              radius="sm"
               classNames={{
                 root: classes['set-password-form__text-input--root'],
                 label: classes['set-password-form__text-input--label'],
@@ -86,7 +85,6 @@ export function SetPasswordForm({ handleSetPassword }: Props): JSX.Element {
               placeholder={String(t('setPasswordView.form.confirmPassword'))}
               label={t('setPasswordView.form.confirmPassword')}
               withAsterisk
-              radius="sm"
               classNames={{
                 label: classes['set-password-form__text-input--label'],
                 root: classes['set-password-form__text-input--root'],

--- a/packages/lib/src/components/SetPassword/SetPasswordForm.tsx
+++ b/packages/lib/src/components/SetPassword/SetPasswordForm.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from 'next-i18next'
 import { Controller } from 'react-hook-form'
 
 import { useZodForm } from '../../hooks'
+import classes from './SetPasswordForm.module.css'
 
 type Props = {
   handleSetPassword: (password: SetPasswordInput['password']) => void
@@ -56,19 +57,17 @@ export function SetPasswordForm({ handleSetPassword }: Props): JSX.Element {
               label={t('setPasswordView.form.newPassword')}
               withAsterisk
               radius="sm"
-              mb="md"
-              styles={{
-                label: {
-                  fontWeight: 'bold',
-                },
+              classNames={{
+                root: classes['set-password-form__text-input--root'],
+                label: classes['set-password-form__text-input--label'],
               }}
             />
           )}
         />
 
-        <Box mt="-1.5rem" h="0.8rem">
+        <Box className={classes['set-password-form__error-box']}>
           {formState.errors.password && (
-            <Text ml={5} fz="xs" color="red">
+            <Text className={classes['set-password-form__error-text']}>
               {formState.errors.password?.message
                 ? String(t(formState.errors.password.message))
                 : null}
@@ -77,7 +76,7 @@ export function SetPasswordForm({ handleSetPassword }: Props): JSX.Element {
         </Box>
       </Stack>
 
-      <Stack gap="xs" mt="sm">
+      <Stack gap="xs" className={classes['set-password-form__stack']}>
         <Controller
           name="confirmPassword"
           control={control}
@@ -88,19 +87,17 @@ export function SetPasswordForm({ handleSetPassword }: Props): JSX.Element {
               label={t('setPasswordView.form.confirmPassword')}
               withAsterisk
               radius="sm"
-              mb="md"
-              styles={{
-                label: {
-                  fontWeight: 'bold',
-                },
+              classNames={{
+                label: classes['set-password-form__text-input--label'],
+                root: classes['set-password-form__text-input--root'],
               }}
             />
           )}
         />
 
-        <Box mt="-1.5rem" h="0.8rem">
+        <Box className={classes['set-password-form__error-box']}>
           {formState.errors.confirmPassword && (
-            <Text ml={5} fz="xs" color="red">
+            <Text className={classes['set-password-form__error-text']}>
               {formState.errors.confirmPassword?.message
                 ? String(t(formState.errors.confirmPassword.message))
                 : null}
@@ -109,7 +106,11 @@ export function SetPasswordForm({ handleSetPassword }: Props): JSX.Element {
         </Box>
       </Stack>
 
-      <Button mt="md" fullWidth type="submit">
+      <Button
+        className={classes['set-password-form__button']}
+        fullWidth
+        type="submit"
+      >
         {t('setPasswordView.form.submit')}
       </Button>
     </form>

--- a/packages/lib/src/components/SetPassword/components/SetPasswordSuccessMessage.module.css
+++ b/packages/lib/src/components/SetPassword/components/SetPasswordSuccessMessage.module.css
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .set-password-success-message__title {
   margin-bottom: var(--mantine-spacing-md);
 }

--- a/packages/lib/src/components/SetPassword/components/SetPasswordSuccessMessage.module.css
+++ b/packages/lib/src/components/SetPassword/components/SetPasswordSuccessMessage.module.css
@@ -1,0 +1,16 @@
+.set-password-success-message__title {
+  margin-bottom: var(--mantine-spacing-md);
+}
+
+.set-password-success-message__text {
+  font-size: var(--mantine-font-size-sm);
+}
+
+.set-password-success-message__button {
+  margin-top: var(--mantine-spacing-md);
+}
+
+.set-password-success-message__next-link {
+  text-decoration: none;
+  color: var(--mantine-color-white);
+}

--- a/packages/lib/src/components/SetPassword/components/SetPasswordSuccessMessage.tsx
+++ b/packages/lib/src/components/SetPassword/components/SetPasswordSuccessMessage.tsx
@@ -21,23 +21,33 @@ import { Button, Center, Stack, Text, Title } from '@mantine/core'
 import NextLink from 'next/link'
 import { useTranslation } from 'next-i18next'
 
+import classes from './SetPasswordSuccessMessage.module.css'
+
 export function SetPasswordSuccessMessage(): JSX.Element {
   const { t } = useTranslation()
 
   return (
     <Center>
       <Stack>
-        <Title order={4} mb="md">
+        <Title
+          order={4}
+          className={classes['set-password-success-message__title']}
+        >
           {t('setPasswordView.successMessage.title')}
         </Title>
 
-        <Text size="sm">{t('setPasswordView.successMessage.text')}</Text>
+        <Text className={classes['set-password-success-message__text']}>
+          {t('setPasswordView.successMessage.text')}
+        </Text>
 
         <NextLink
           href="/login"
-          style={{ textDecoration: 'none', color: 'white' }}
+          className={classes['set-password-success-message__next-link']}
         >
-          <Button mt="md" fullWidth>
+          <Button
+            className={classes['set-password-success-message__button']}
+            fullWidth
+          >
             {t('setPasswordView.successMessage.button')}
           </Button>
         </NextLink>

--- a/packages/lib/src/components/Table/Table.module.css
+++ b/packages/lib/src/components/Table/Table.module.css
@@ -17,14 +17,14 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.tableColSticky:first-child {
+.table__col-sticky:first-child {
   position: -webkit-sticky;
   position: sticky;
   left: 0;
   z-index: 10;
 }
 
-.table__colHeader {
+.table__col-header {
   cursor: progress;
 
   @mixin light {
@@ -34,4 +34,27 @@
   @mixin dark {
     color: var(--mantine-color-dark-1);
   }
+}
+
+.table__select {
+  margin-top: var(--mantine-spacing-xs);
+  margin-bottom: var(--mantine-spacing-xs);
+}
+
+.table__table-row--sticky {
+  border-bottom: 2px solid white;
+  border-top: 2px solid white;
+
+  @mixin dark {
+    background-color: var(--mantine-color-dark-7);
+  }
+
+  @mixin light {
+    background-color: white;
+  }
+}
+
+.table__table-row {
+  border-bottom: 2px solid white;
+  border-top: 2px solid white;
 }

--- a/packages/lib/src/components/Table/Table.module.css
+++ b/packages/lib/src/components/Table/Table.module.css
@@ -25,8 +25,6 @@
 }
 
 .table__col-header {
-  cursor: progress;
-
   @mixin light {
     color: var(--mantine-color-dark-4);
   }
@@ -34,6 +32,10 @@
   @mixin dark {
     color: var(--mantine-color-dark-1);
   }
+}
+
+.table__col-header--cursor-pointer {
+  cursor: pointer;
 }
 
 .table__select {

--- a/packages/lib/src/components/Table/Table.tsx
+++ b/packages/lib/src/components/Table/Table.tsx
@@ -59,7 +59,11 @@ export function Table<T>({
                       align="center"
                       justify="flex-start"
                       gap="sm"
-                      className={classes['table__col-header']}
+                      className={
+                        header.column.getCanSort()
+                          ? `${classes['table__col-header']} ${classes['table__col-header--cursor-pointer']}`
+                          : classes['table__col-header']
+                      }
                       onClick={header.column.getToggleSortingHandler()}
                       w={header.column.getSize()}
                     >

--- a/packages/lib/src/components/Table/Table.tsx
+++ b/packages/lib/src/components/Table/Table.tsx
@@ -53,13 +53,13 @@ export function Table<T>({
                   <MantineTable.Th
                     key={header.id}
                     style={{ verticalAlign: 'top' }}
-                    className={classes['tableColSticky']}
+                    className={classes['table__col-sticky']}
                   >
                     <Flex
                       align="center"
                       justify="flex-start"
                       gap="sm"
-                      className={classes['table__colHeader']}
+                      className={classes['table__col-header']}
                       onClick={header.column.getToggleSortingHandler()}
                       w={header.column.getSize()}
                     >
@@ -77,7 +77,7 @@ export function Table<T>({
                     {showFilter && header.column.getCanFilter() ? (
                       <Select
                         size="xs"
-                        my="xs"
+                        className={classes.table__select}
                         data={filterData ? filterData[header.column.id] : []}
                         searchable
                         clearable
@@ -103,17 +103,17 @@ export function Table<T>({
             {tableModel.getRowModel().rows.map(row => (
               <MantineTable.Tr
                 key={row.id}
-                style={{
-                  borderBottom: '2px solid white',
-                  borderTop: '2px solid white',
-                }}
-                className={firstColSticky ? classes['tableRowBg'] : undefined}
+                className={
+                  firstColSticky
+                    ? classes['table__table-row--sticky']
+                    : classes['table__table-row']
+                }
               >
                 {row.getVisibleCells().map(cell => (
                   <MantineTable.Td
                     key={cell.id}
                     width={cell.column.getSize()}
-                    className={classes['tableColSticky']}
+                    className={classes['table__col-sticky']}
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </MantineTable.Td>

--- a/packages/lib/src/components/TablePagination/TablePagination.module.css
+++ b/packages/lib/src/components/TablePagination/TablePagination.module.css
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 .table-pagination__flex--margin-top {
   margin-top: var(--mantine-spacing-xs);
 }

--- a/packages/lib/src/components/TablePagination/TablePagination.module.css
+++ b/packages/lib/src/components/TablePagination/TablePagination.module.css
@@ -1,0 +1,16 @@
+.table-pagination__flex--margin-top {
+  margin-top: var(--mantine-spacing-xs);
+}
+
+.table-pagination__flex--margin-right {
+  margin-right: var(--mantine-spacing-xl);
+}
+
+.table-pagination__text {
+  font-size: var(--mantine-font-size-sm);
+  margin-right: var(--mantine-spacing-xs);
+}
+
+.table-pagination__select {
+  width: 70;
+}

--- a/packages/lib/src/components/TablePagination/TablePagination.tsx
+++ b/packages/lib/src/components/TablePagination/TablePagination.tsx
@@ -22,6 +22,8 @@ import { Flex, Pagination, Select, Text } from '@mantine/core'
 import { Table as TanstackTable } from '@tanstack/react-table'
 import { useTranslation } from 'next-i18next'
 
+import classes from './TablePagination.module.css'
+
 type Props<T> = {
   table: TanstackTable<T>
   pageSize: PaginatedResponse<T>['size']
@@ -42,16 +44,22 @@ export function TablePagination<T>({
   const { t } = useTranslation()
 
   return (
-    <Flex align="center" mt="xs">
-      <Flex align="center" mr="xl">
-        <Text size="sm" mr="xs">
+    <Flex
+      align="center"
+      className={classes['table-pagination__flex--margin-top']}
+    >
+      <Flex
+        align="center"
+        className={classes['table-pagination__flex--margin-right']}
+      >
+        <Text className={classes['table-pagination__text']}>
           {t('table.footer.pageSize')}
         </Text>
 
         <Select
           defaultValue={String(pageSize)}
           data={['10', '20', '30', '40', '50', '100']}
-          w={70}
+          className={classes['table-pagination__select']}
           onChange={e => {
             table.setPageSize(Number(e))
             setPageSize(Number(e))

--- a/packages/lib/src/components/Translations/Translations.module.css
+++ b/packages/lib/src/components/Translations/Translations.module.css
@@ -20,6 +20,8 @@
 .translations-tree-container {
   padding-left: var(--mantine-spacing-lg);
   padding-top: var(--mantine-spacing-lg);
+  box-shadow: var(--mantine-shadow-sm);
+  border-radius: var(--mantine-radius-sm);
 
   @mixin dark {
     background-color: var(--mantine-color-dark-7);

--- a/packages/lib/src/components/Translations/Translations.tsx
+++ b/packages/lib/src/components/Translations/Translations.tsx
@@ -227,12 +227,7 @@ export function Translations({
         />
       </Flex>
 
-      <Card
-        shadow="sm"
-        radius="sm"
-        withBorder
-        className={classes['translations-tree-container']}
-      >
+      <Card withBorder className={classes['translations-tree-container']}>
         {!Object.keys(filteredTranslations).length ? (
           <Text
             className={

--- a/packages/lib/src/components/User/UserForm.tsx
+++ b/packages/lib/src/components/User/UserForm.tsx
@@ -300,7 +300,7 @@ export function UserForm({
             {...field}
             checked={field.value}
             value={String(field.value)}
-            color="blue"
+            color="var(--mantine-primary-color-filled)"
             size="md"
             className={classes['userForm__enableToggle']}
             label={t('addUpdateUserView.form.status')}

--- a/packages/lib/src/components/User/UserForm.tsx
+++ b/packages/lib/src/components/User/UserForm.tsx
@@ -106,7 +106,6 @@ export function UserForm({
                 label={t('addUpdateUserView.form.firstName')}
                 size="sm"
                 variant="filled"
-                radius="sm"
                 withAsterisk
               />
             )}
@@ -137,7 +136,6 @@ export function UserForm({
                 label={t('addUpdateUserView.form.lastName')}
                 size="sm"
                 variant="filled"
-                radius="sm"
                 withAsterisk
               />
             )}
@@ -176,7 +174,6 @@ export function UserForm({
                 withAsterisk
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -206,7 +203,6 @@ export function UserForm({
                 label={t('addUpdateUserView.form.password')}
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -242,7 +238,6 @@ export function UserForm({
                 label={t('addUpdateUserView.form.phone')}
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -271,7 +266,6 @@ export function UserForm({
                 label={t('addUpdateUserView.form.mobile')}
                 size="sm"
                 variant="filled"
-                radius="sm"
               />
             )}
           />
@@ -321,7 +315,6 @@ export function UserForm({
             render={({ field }) => (
               <Select
                 {...field}
-                radius="sm"
                 withAsterisk
                 label={t('addUpdateUserView.form.language')}
                 placeholder={String(t('addUpdateUserView.form.language'))}
@@ -352,7 +345,6 @@ export function UserForm({
               <MultiSelect
                 {...field}
                 disabled={isSso}
-                radius="sm"
                 label={t('addUpdateUserView.form.role')}
                 data={rolesData}
                 withAsterisk


### PR DESCRIPTION
## DESCRIPTION

In this Pull Request the following has been refactored: 

- replace inline styles with css modules
- replace mantine style props with css modules
- replace hardcoded colors with theme variables
- set darkmode styling correctly with css modules
- use [BEM](https://getbem.com/introduction/) for class names
- cursor state in the table views has been fixed 
- update docs concerning styles

Not in scope: 
- refactor navbar since it's an own issue

### TO-DO

- [x] update docs
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #527 
closes #537 
closes #553 
