### PR TITLE
fix: adjust z-index for notification

### DIFF
--- a/packages/app/src/utils/withBaseStylingShowNotification.ts
+++ b/packages/app/src/utils/withBaseStylingShowNotification.ts
@@ -52,6 +52,11 @@ export function withBaseStylingShowNotification(
         : props.color === 'error'
         ? 'red'
         : 'blue',
-    style: props.style ?? { position: 'fixed', top: '20px', right: '10px' },
+    style: props.style ?? {
+      position: 'fixed',
+      top: '20px',
+      right: '10px',
+      zIndex: 100,
+    },
   })
 }


### PR DESCRIPTION
## DESCRIPTION

Since the Mantine Update the notifications were displayed beneath the header and therefore were hard to read. In this PR the style of the notification component has been adjusted, so that it is displayed correctly. 


### TO-DO

- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #558 
