### PR TITLE
feat: enable props forwarding for appshell mantine components

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -1,5 +1,15 @@
 # Migrations
 
+## [x.y.z (DD.MM.YYYY)](#)
+
+### `src/components/layouts/AuthLayout.module.css`
+
+- add file
+
+### `src/components/layouts/AuthLayout.tsx`
+
+- add built-in Mantine props forwarding for `AppShell`
+
 ## [7.0.1 (23.05.2024)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.0.0...essencium-app-v7.0.1)
 
 ### `src/utils/withBaseStylingShowNotification.ts`

--- a/packages/app/src/components/layouts/AuthLayout.module.css
+++ b/packages/app/src/components/layouts/AuthLayout.module.css
@@ -1,0 +1,3 @@
+.app-shell {
+  padding: var(--mantine-spacing-lg);
+}

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -24,7 +24,12 @@ import {
   NavBar,
 } from '@frachtwerk/essencium-lib'
 import { FooterLink, NavLink, RIGHTS } from '@frachtwerk/essencium-types'
-import { AppShell, AppShellMain, useMantineTheme } from '@mantine/core'
+import {
+  AppShell,
+  AppShellMain,
+  AppShellProps,
+  useMantineTheme,
+} from '@mantine/core'
 import { useDisclosure, useMediaQuery } from '@mantine/hooks'
 import { Spotlight, SpotlightActionData } from '@mantine/spotlight'
 import {
@@ -50,7 +55,9 @@ import { useGetMe, useGetTranslations, userAtom, userRightsAtom } from '@/api'
 import { useCreateFeedback } from '@/api/feedback'
 import { logout, withBaseStylingShowNotification } from '@/utils'
 
-type Props = {
+import classes from './AuthLayout.module.css'
+
+type Props = AppShellProps & {
   children: React.ReactNode
   routeName?: string
   version?: string
@@ -147,6 +154,7 @@ export function AuthLayout({
   children,
   routeName,
   version,
+  ...props
 }: Props): JSX.Element | null {
   const router = useRouter()
 
@@ -308,7 +316,8 @@ export function AuthLayout({
           breakpoint: 'sm',
           collapsed: { mobile: !mobileNavBarOpened },
         }}
-        padding={16}
+        className={classes['app-shell']}
+        {...props}
       >
         <Header
           user={user}

--- a/packages/lib/src/components/Footer/Footer.tsx
+++ b/packages/lib/src/components/Footer/Footer.tsx
@@ -18,22 +18,27 @@
  */
 
 import { FooterLink } from '@frachtwerk/essencium-types'
-import { AppShellFooter, Flex, Text } from '@mantine/core'
+import { AppShellFooter, AppShellFooterProps, Flex, Text } from '@mantine/core'
 import { IconCopyright } from '@tabler/icons-react'
 import NextLink from 'next/link'
 import { useTranslation } from 'next-i18next'
 
 import classes from './Footer.module.css'
 
-type Props = {
+type Props = AppShellFooterProps & {
   links: FooterLink[]
 }
 
-export function Footer({ links }: Props): JSX.Element {
+export function Footer({ links, ...props }: Props): JSX.Element {
   const { t } = useTranslation()
 
   return (
-    <AppShellFooter className={classes['footer__app-shell']}>
+    <AppShellFooter
+      {...props}
+      className={`${classes['footer__app-shell']} ${
+        props.className ? props.className : ''
+      }`}
+    >
       <Flex
         justify={{ base: 'center', xs: 'space-between' }}
         direction="row"

--- a/packages/lib/src/components/Header/Header.tsx
+++ b/packages/lib/src/components/Header/Header.tsx
@@ -20,6 +20,7 @@
 import { UserOutput } from '@frachtwerk/essencium-types'
 import {
   AppShellHeader,
+  AppShellHeaderProps,
   Burger,
   Flex,
   Group,
@@ -29,17 +30,28 @@ import {
 import { SearchBar, ThemeSelector, UserMenu } from './components'
 import classes from './Header.module.css'
 
-type Props = {
+type Props = AppShellHeaderProps & {
   user: UserOutput | undefined
   isOpen: boolean
   handleOpenNav: () => void
 }
 
-export function Header({ user, isOpen, handleOpenNav }: Props): JSX.Element {
+export function Header({
+  user,
+  isOpen,
+  handleOpenNav,
+  ...props
+}: Props): JSX.Element {
   const theme = useMantineTheme()
 
   return (
-    <AppShellHeader withBorder={false} className={classes['header__app-shell']}>
+    <AppShellHeader
+      withBorder={false}
+      {...props}
+      className={`${classes['header__app-shell']} ${
+        props.className ? props.className : ''
+      }`}
+    >
       <Flex
         className={classes.header__content}
         justify="space-between"

--- a/packages/lib/src/components/NavBar/NavBar.tsx
+++ b/packages/lib/src/components/NavBar/NavBar.tsx
@@ -20,6 +20,7 @@
 import { NavLink } from '@frachtwerk/essencium-types'
 import {
   AppShellNavbar,
+  AppShellNavbarProps,
   AppShellSection,
   Box,
   Code,
@@ -36,7 +37,7 @@ import { Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { NavLinks } from './components'
 import classes from './NavBar.module.css'
 
-type Props = {
+type Props = AppShellNavbarProps & {
   isMobile: boolean
   links: NavLink[]
   userRights?: string[] | null
@@ -62,6 +63,7 @@ export function NavBar({
   setFoldedNav,
   fixedNav,
   setFixedNav,
+  ...props
 }: Props): JSX.Element {
   const { colorScheme } = useMantineColorScheme()
   const theme = useMantineTheme()
@@ -108,12 +110,13 @@ export function NavBar({
           handleMouseLeave()
         }
       }}
-      className={
+      zIndex={100}
+      {...props}
+      className={`${
         isMobile
           ? classes['navBar__container-mobile']
           : classes['navBar__container']
-      }
-      zIndex={100}
+      } ${props.className ? props.className : ''}`}
     >
       <AppShellSection className={classes['navBar__versionContainer']}>
         <Group gap="xs" align="center">

--- a/packages/lib/src/components/Table/Table.tsx
+++ b/packages/lib/src/components/Table/Table.tsx
@@ -16,14 +16,14 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
-import { Flex, Select, Table as MantineTable } from '@mantine/core'
+import { Flex, Select, Table as MantineTable, TableProps } from '@mantine/core'
 import { IconSortAscending2, IconSortDescending2 } from '@tabler/icons-react'
 import { flexRender, Table as TanstackTable } from '@tanstack/react-table'
 import { Dispatch, SetStateAction } from 'react'
 
 import classes from './Table.module.css'
 
-type Props<T> = {
+type Props<T> = TableProps & {
   tableModel: TanstackTable<T>
   onFilterChange?: (key: string, value: string | null) => void
   showFilter?: boolean
@@ -41,11 +41,17 @@ export function Table<T>({
   filterValue,
   setFilterValue,
   firstColSticky,
+  ...props
 }: Props<T>): JSX.Element {
   return (
     <Flex direction="column" align="end">
       <div style={{ overflowX: 'auto', width: '100%' }}>
-        <MantineTable striped highlightOnHover withRowBorders={false}>
+        <MantineTable
+          striped
+          highlightOnHover
+          withRowBorders={false}
+          {...props}
+        >
           <MantineTable.Thead aria-label="header-row">
             {tableModel.getHeaderGroups().map(headerGroup => (
               <MantineTable.Tr key={headerGroup.id}>


### PR DESCRIPTION
## DESCRIPTION

This PR enables the ability to pass all Mantine props to our custom components that forward them to the Mantine components. The win here is much higher customizability.

### TO-DO

- [x] implement and update tests
- [x] update docs
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment