### PR TITLE
fix: move feedbackWidget to footer

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -1,5 +1,11 @@
 # Migrations
 
+## [?.?.? (DD.MM.YYYY)]()
+
+### `src/components/layouts/AuthLayout.tsx`
+
+- use `FeedbackWidget` as child for `Footer`
+
 ## [7.1.0 (29.05.2024)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.0.1...essencium-app-v7.1.0)
 
 ### `src/components/layouts/AuthLayout.module.css`

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -353,20 +353,20 @@ export function AuthLayout({
           }
         />
 
-        <Footer links={FOOTER_LINKS} />
+        <Footer links={FOOTER_LINKS}>
+          {user ? (
+            <FeedbackWidget
+              currentUser={user}
+              createFeedback={createFeedback}
+              feedbackCreated={feedbackCreated}
+              feedbackFailed={feedbackFailed}
+              feedbackSending={feedbackSending}
+              createNotification={withBaseStylingShowNotification}
+            />
+          ) : null}
+        </Footer>
 
         <AppShellMain>{showChildren ? children : null}</AppShellMain>
-
-        {user ? (
-          <FeedbackWidget
-            currentUser={user}
-            createFeedback={createFeedback}
-            feedbackCreated={feedbackCreated}
-            feedbackFailed={feedbackFailed}
-            feedbackSending={feedbackSending}
-            createNotification={withBaseStylingShowNotification}
-          />
-        ) : null}
       </AppShell>
     </>
   )

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -223,17 +223,14 @@ export function FeedbackWidget({
     <>
       <ActionIcon
         variant="filled"
-        size="xl"
+        size="lg"
         radius="xl"
         style={{
-          position: 'fixed',
-          bottom: 80,
-          right: 25,
           zIndex: 20,
         }}
         onClick={toggle}
       >
-        <IconMessageDots size={30} />
+        <IconMessageDots size={24} />
       </ActionIcon>
 
       <Dialog
@@ -243,7 +240,6 @@ export function FeedbackWidget({
           onCloseWidget()
         }}
         h={openInput ? 'auto' : '180px'}
-        position={{ bottom: 100, right: 80 }}
         className={
           isCapturingScreenshot
             ? classes['feedback-widget__dialog--display']

--- a/packages/lib/src/components/Footer/Footer.module.css
+++ b/packages/lib/src/components/Footer/Footer.module.css
@@ -17,15 +17,14 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-.footer__app-shell {
-  padding: var(--mantine-spacing-md);
-}
+
 
 .footer__flex {
-  margin-left: var(--mantine-spacing-xs);
+  padding: 0 var(--mantine-spacing-lg);
 }
 
 .footer__text {
+
   @mixin dark {
     color: var(--mantine-color-gray-0);
   }

--- a/packages/lib/src/components/Footer/Footer.tsx
+++ b/packages/lib/src/components/Footer/Footer.tsx
@@ -29,33 +29,29 @@ type Props = AppShellFooterProps & {
   links: FooterLink[]
 }
 
-export function Footer({ links, ...props }: Props): JSX.Element {
+export function Footer({ links, children, ...props }: Props): JSX.Element {
   const { t } = useTranslation()
 
   return (
     <AppShellFooter
       {...props}
-      className={`${classes['footer__app-shell']} ${
-        props.className ? props.className : ''
-      }`}
+      className={props.className ? props.className : ''}
     >
       <Flex
         justify={{ base: 'center', xs: 'space-between' }}
         direction="row"
         wrap="wrap"
+        align="center"
+        h="100%" // not applied with normal css
+        className={classes.footer__flex}
       >
-        <Flex
-          gap="xs"
-          align="center"
-          className={classes.footer__flex}
-          visibleFrom="sm"
-        >
+        <Flex gap="xs" align="center" visibleFrom="sm">
           <IconCopyright size="16" />
 
           <Text> {t('footer.license')} </Text>
         </Flex>
 
-        <Flex direction="row" gap="lg">
+        <Flex direction="row" gap="lg" align="center">
           {links.map(link => (
             <Text
               component={NextLink}
@@ -66,6 +62,8 @@ export function Footer({ links, ...props }: Props): JSX.Element {
               {t(link.label)}
             </Text>
           ))}
+
+          {children}
         </Flex>
       </Flex>
     </AppShellFooter>


### PR DESCRIPTION
## DESCRIPTION

FeedbackWidget is moved to footer as child

### TO-DO

- [x] ~implement and update tests~
- [x] ~update docs~
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #584 
