### PR TITLE
fix: allow passing classes to button component

### DIFF
--- a/packages/lib/src/components/Header/components/UserMenu/UserMenu.tsx
+++ b/packages/lib/src/components/Header/components/UserMenu/UserMenu.tsx
@@ -28,6 +28,7 @@ import classes from './UserMenu.module.css'
 type Props = {
   user: UserOutput
   className?: {
+    button?: string
     group?: string
     mail?: string
   }
@@ -40,7 +41,9 @@ export function UserMenu({ user, className }: Props): JSX.Element {
     <UnstyledButton
       component={NextLink}
       href="/profile"
-      className={classes['user-menu__button']}
+      className={`${classes['user-menu__button']} ${
+        className?.button ? className.button : ''
+      }`}
       aria-label={t('header.profile.arialLabel') as string}
     >
       <Group


### PR DESCRIPTION
## DESCRIPTION

This PR adds the ability to pass a custom class to the `UserMenu.tsx` component's unstyled button.

### TO-DO

- [x] implement and update tests
- [x] update docs
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment