### PR TITLE
fix: replace hard-coded app name with i18n variable

### DIFF
--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -53,7 +53,11 @@ import React, { useEffect, useState } from 'react'
 
 import { useGetMe, useGetTranslations, userAtom, userRightsAtom } from '@/api'
 import { useCreateFeedback } from '@/api/feedback'
-import { logout, withBaseStylingShowNotification } from '@/utils'
+import {
+  getTranslation,
+  logout,
+  withBaseStylingShowNotification,
+} from '@/utils'
 
 import classes from './AuthLayout.module.css'
 
@@ -287,7 +291,9 @@ export function AuthLayout({
     router.push('/login')
   }
 
-  const pageTitle = `${routeName ? `${routeName} -` : ''} Essencium`
+  const pageTitle = `${routeName ? `${routeName} -` : ''} ${getTranslation(
+    'header.title',
+  )}`
 
   const isNotMobile = useMediaQuery('(min-width: 48em)') // equals mantine breakpoint sm
 

--- a/packages/app/src/components/layouts/PublicLayout.tsx
+++ b/packages/app/src/components/layouts/PublicLayout.tsx
@@ -20,6 +20,8 @@
 import { Center } from '@mantine/core'
 import Head from 'next/head'
 
+import { getTranslation } from '@/utils'
+
 type Props = {
   children: React.ReactNode
   routeName?: string
@@ -29,7 +31,9 @@ export function PublicLayout({
   children,
   routeName,
 }: Props): JSX.Element | null {
-  const pageTitle = `${routeName ? `${routeName} -` : ''} Essencium`
+  const pageTitle = `${routeName ? `${routeName} -` : ''} ${getTranslation(
+    'header.title',
+  )}`
 
   return (
     <Center>


### PR DESCRIPTION
## DESCRIPTION

This PR removes the hard-coded title for layout files and replaces them with a i18n variable (`header.title`)

### TO-DO

- [x] implement and update tests
- [x] update docs
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment