### PR TITLE
fix(frontend): set first table col only sticky on concerning prop

### DIFF
--- a/packages/lib/src/components/Table/Table.module.css
+++ b/packages/lib/src/components/Table/Table.module.css
@@ -24,16 +24,6 @@
   z-index: 10;
 }
 
-.table__col-header {
-  @mixin light {
-    color: var(--mantine-color-dark-4);
-  }
-
-  @mixin dark {
-    color: var(--mantine-color-dark-1);
-  }
-}
-
 .table__col-header--cursor-pointer {
   cursor: pointer;
 }

--- a/packages/lib/src/components/Table/Table.tsx
+++ b/packages/lib/src/components/Table/Table.tsx
@@ -59,7 +59,9 @@ export function Table<T>({
                   <MantineTable.Th
                     key={header.id}
                     style={{ verticalAlign: 'top' }}
-                    className={classes['table__col-sticky']}
+                    className={
+                      firstColSticky ? classes['table__col-sticky'] : ''
+                    }
                   >
                     <Flex
                       align="center"
@@ -67,8 +69,8 @@ export function Table<T>({
                       gap="sm"
                       className={
                         header.column.getCanSort()
-                          ? `${classes['table__col-header']} ${classes['table__col-header--cursor-pointer']}`
-                          : classes['table__col-header']
+                          ? classes['table__col-header--cursor-pointer']
+                          : ''
                       }
                       onClick={header.column.getToggleSortingHandler()}
                       w={header.column.getSize()}
@@ -123,7 +125,9 @@ export function Table<T>({
                   <MantineTable.Td
                     key={cell.id}
                     width={cell.column.getSize()}
-                    className={classes['table__col-sticky']}
+                    className={
+                      firstColSticky ? classes['table__col-sticky'] : ''
+                    }
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </MantineTable.Td>


### PR DESCRIPTION
## DESCRIPTION

The first table column is currently always sticky. This PR fixes the bug.

### TO-DO

- [x] ~implement and update tests~
- [x] ~update docs~
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

-
