### PR TITLE
refactor: pass arbitrary number of key value pairs to feedback widget

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -1,5 +1,9 @@
 # Migrations
 
+### `src/components/layouts/AuthLayout.tsx`
+
+- `FeedbackWidget` Component now accepts a new prop "additionalInformation" to pass an arbitrary number of key value pairs to the component
+
 ## [7.2.0 (12.06.2024)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.1.1...essencium-app-v7.2.0)
 
 ### E2E test fixes

--- a/packages/app/public/locales/de/common.json
+++ b/packages/app/public/locales/de/common.json
@@ -428,6 +428,9 @@
     "screenshot": {
       "label": "Screenshot aufnehmen",
       "created": "Screenshot erstellt"
+    },
+    "openButton": {
+      "ariaLabel": "Feedback Widget öffnen"
     }
   }
 }

--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -428,6 +428,9 @@
     "screenshot": {
       "label": "Capture Screenshot",
       "created": "Screenshot captured"
+    },
+    "openButton": {
+      "ariaLabel": "Open Feedback Widget"
     }
   }
 }

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -308,17 +308,6 @@ export function AuthLayout({
           </Footer>
 
           <AppShellMain>{children}</AppShellMain>
-
-          {user ? (
-            <FeedbackWidget
-              currentUser={user}
-              createFeedback={createFeedback}
-              feedbackCreated={feedbackCreated}
-              feedbackFailed={feedbackFailed}
-              feedbackSending={feedbackSending}
-              createNotification={withBaseStylingShowNotification}
-            />
-          ) : null}
         </AppShell>
       ) : (
         <LoadingSpinner show />

--- a/packages/app/src/pages/api/feedback.ts
+++ b/packages/app/src/pages/api/feedback.ts
@@ -54,11 +54,10 @@ export async function sendFeedbackEmail(
       : [],
     subject: 'New Feedback Submission',
     text: `The following feedback was submitted:
-    User: ${feedback.firstName} ${feedback.lastName}
-    Email: ${feedback.email}
-    Type: ${feedback.feedbackType}
-    Path: ${feedback.path}
-    Message: ${feedback.message}  
+     ${Object.keys(feedback)
+       .map(key => `${key}: ${feedback[key]}`)
+       .join('\n')}
+     
     `,
   }
 

--- a/packages/app/src/pages/api/feedback.ts
+++ b/packages/app/src/pages/api/feedback.ts
@@ -55,6 +55,7 @@ export async function sendFeedbackEmail(
     subject: 'New Feedback Submission',
     text: `The following feedback was submitted:
      ${Object.keys(feedback)
+       .filter(key => key !== 'screenshot')
        .map(key => `${key}: ${feedback[key]}`)
        .join('\n')}
      

--- a/packages/app/src/pages/api/feedback.ts
+++ b/packages/app/src/pages/api/feedback.ts
@@ -17,7 +17,11 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { feedbackFormSchema, FeedbackInput } from '@frachtwerk/essencium-types'
+import {
+  baseFeedbackFormSchema,
+  feedbackFormSchema,
+  FeedbackInput,
+} from '@frachtwerk/essencium-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 import nodemailer from 'nodemailer'
 
@@ -27,6 +31,8 @@ const RequestMethods = {
   PUT: 'PUT',
   DELETE: 'DELETE',
 } as const
+
+const fixedFeedbackProperties = Object.keys(baseFeedbackFormSchema.shape)
 
 export async function sendFeedbackEmail(
   feedback: FeedbackInput,
@@ -39,6 +45,22 @@ export async function sendFeedbackEmail(
       pass: process.env.SMTP_PASSWORD,
     },
   })
+
+  const formattedFeedback = `
+The following feedback was submitted:
+
+  User: ${feedback.firstName} ${feedback.lastName}
+  Email: ${feedback.email}
+  Type: ${feedback.feedbackType}
+  Path: ${feedback.path}
+  Message: ${feedback.message}
+${Object.keys(feedback)
+  .filter(key => !fixedFeedbackProperties.includes(key))
+  .map(
+    key => `  ${key.charAt(0).toUpperCase() + key.slice(1)}: ${feedback[key]}`,
+  )
+  .join('\n')}
+`
 
   const mailOptions = {
     from: process.env.MAIL_FROM,
@@ -53,13 +75,7 @@ export async function sendFeedbackEmail(
         ]
       : [],
     subject: 'New Feedback Submission',
-    text: `The following feedback was submitted:
-     ${Object.keys(feedback)
-       .filter(key => key !== 'screenshot')
-       .map(key => `${key}: ${feedback[key]}`)
-       .join('\n')}
-     
-    `,
+    text: formattedFeedback,
   }
 
   await transporter.sendMail(mailOptions)

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.module.css
@@ -62,7 +62,6 @@
 
 .feedback-widget__error-box {
   height: 0.8rem;
-  margin-top: -0.8rem;
   margin-bottom: 0.6em;
 }
 

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.test.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.test.tsx
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { AppShell, MantineProvider } from '@mantine/core'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+import { FeedbackWidget } from './FeedbackWidget'
+
+vi.mock('@mantine/core', async () => {
+  const mantineCore = (await vi.importActual('@mantine/core')) as Record<
+    string,
+    unknown
+  >
+
+  return {
+    ...mantineCore,
+    useMantineTheme: () => ({
+      colors: { gray: [] },
+    }),
+  }
+})
+
+const mockedProps = {
+  spyFunctions: {
+    createFeedback: vi.fn(),
+  },
+  createNotification: () => {},
+  user: {
+    id: '12345',
+    email: 'devnull@frachtwerk.de',
+    firstName: 'Admin',
+    lastName: 'User',
+    locale: 'de',
+    roles: [
+      {
+        name: 'USER',
+        description: 'User',
+        defaultRole: true,
+        editable: false,
+        protected: true,
+        rights: [],
+      },
+      {
+        name: 'ADMIN',
+        description: 'Administrator',
+        defaultRole: true,
+        editable: false,
+        protected: true,
+        rights: [],
+      },
+    ],
+    source: 'local',
+    enabled: true,
+    mobile: '88889999',
+    phone: '11111111',
+  },
+}
+
+describe('FeedbackWidget', () => {
+  beforeAll(() => {
+    vi.mock('next/router', () => ({
+      useRouter: () => ({
+        router: vi.fn(),
+      }),
+    }))
+  })
+
+  it('should render the button to open the feedback widget', () => {
+    const component = render(
+      <MantineProvider>
+        <AppShell>
+          <FeedbackWidget
+            currentUser={mockedProps.user}
+            createFeedback={mockedProps.spyFunctions.createFeedback}
+            feedbackCreated={false}
+            feedbackFailed={false}
+            feedbackSending={false}
+            createNotification={mockedProps.createNotification}
+          />
+        </AppShell>
+      </MantineProvider>,
+    )
+
+    const openButton = screen.getByLabelText(
+      'feedbackWidget.openButton.ariaLabel',
+    )
+
+    expect(openButton).toBeDefined()
+
+    fireEvent.click(openButton)
+
+    expect(screen.getByText('feedbackWidget.title')).toBeDefined()
+
+    expect(
+      screen.getAllByRole('button', { name: 'feedbackWidget.issue' })[0],
+    ).toBeDefined()
+
+    expect(
+      screen.getAllByRole('button', { name: 'feedbackWidget.idea' })[0],
+    ).toBeDefined()
+
+    expect(
+      screen.getAllByRole('button', { name: 'feedbackWidget.other' })[0],
+    ).toBeDefined()
+
+    component.unmount()
+  })
+
+  it('should render the feedback form after clicking the issue button', async () => {
+    const component = render(
+      <MantineProvider>
+        <AppShell>
+          <FeedbackWidget
+            currentUser={mockedProps.user}
+            createFeedback={mockedProps.spyFunctions.createFeedback}
+            feedbackCreated={false}
+            feedbackFailed={false}
+            feedbackSending={false}
+            createNotification={mockedProps.createNotification}
+          />
+        </AppShell>
+      </MantineProvider>,
+    )
+
+    const openButton = screen.getByLabelText(
+      'feedbackWidget.openButton.ariaLabel',
+    )
+
+    expect(openButton).toBeDefined()
+
+    fireEvent.click(openButton)
+
+    const issueButton = screen.getAllByRole('button', {
+      name: '',
+    })[1]
+
+    fireEvent.click(issueButton)
+
+    const textArea = (await screen.findByPlaceholderText(
+      'feedbackWidget.placeholder',
+    )) as HTMLTextAreaElement
+
+    expect(textArea).toBeDefined()
+
+    fireEvent.change(textArea, { target: { value: 'DummyText' } })
+
+    expect(textArea.value).toBe('DummyText')
+
+    const submitButton = await screen.findByRole('button', {
+      name: 'feedbackWidget.button',
+    })
+
+    expect(submitButton).toBeDefined()
+
+    const screenshotButton = await screen.findByRole('button', {
+      name: 'feedbackWidget.screenshot.label',
+    })
+
+    expect(screenshotButton).toBeDefined()
+
+    component.unmount()
+  })
+
+  it('should render the success message after submitting the feedback', async () => {
+    const renderedComponent = render(
+      <MantineProvider>
+        <AppShell>
+          <FeedbackWidget
+            currentUser={mockedProps.user}
+            createFeedback={mockedProps.spyFunctions.createFeedback}
+            feedbackCreated
+            feedbackFailed={false}
+            feedbackSending={false}
+            createNotification={mockedProps.createNotification}
+          />
+        </AppShell>
+      </MantineProvider>,
+    )
+
+    const openButton = screen.getByLabelText(
+      'feedbackWidget.openButton.ariaLabel',
+    )
+
+    expect(openButton).toBeDefined()
+
+    fireEvent.click(openButton)
+
+    const issueButton = screen.getAllByRole('button', {
+      name: '',
+    })[1]
+
+    fireEvent.click(issueButton)
+
+    expect(
+      await screen.findByText('feedbackWidget.successMessage'),
+    ).toBeDefined()
+
+    renderedComponent.unmount()
+  })
+
+  it('should render the error message after not submitting the feedback', async () => {
+    const renderedComponent = render(
+      <MantineProvider>
+        <AppShell>
+          <FeedbackWidget
+            currentUser={mockedProps.user}
+            createFeedback={mockedProps.spyFunctions.createFeedback}
+            feedbackCreated={false}
+            feedbackFailed
+            feedbackSending={false}
+            createNotification={mockedProps.createNotification}
+          />
+        </AppShell>
+      </MantineProvider>,
+    )
+
+    const openButton = screen.getByLabelText(
+      'feedbackWidget.openButton.ariaLabel',
+    )
+
+    expect(openButton).toBeDefined()
+
+    fireEvent.click(openButton)
+
+    const issueButton = screen.getAllByRole('button', {
+      name: '',
+    })[1]
+
+    fireEvent.click(issueButton)
+
+    expect(await screen.findByText('feedbackWidget.errorMessage')).toBeDefined()
+
+    renderedComponent.unmount()
+  })
+})

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -129,28 +129,7 @@ export function FeedbackWidget({
     setValue('feedbackType', openInput || OpenInput.Other)
     setValue('screenshot', screenshot || '')
     setValue('path', router.asPath || '')
-
-    if (additionalInformation) {
-      Object.keys(additionalInformation).forEach(key => {
-        const value = additionalInformation[key]
-
-        if (typeof value === 'string') {
-          setValue(key, value)
-        }
-
-        if (Array.isArray(value)) {
-          setValue(key, value.join(', '))
-        }
-      })
-    }
-  }, [
-    currentUser,
-    openInput,
-    screenshot,
-    router.asPath,
-    setValue,
-    additionalInformation,
-  ])
+  }, [currentUser, openInput, screenshot, router.asPath, setValue])
 
   const iconStyling = {
     size: openInput ? 16 : 40,

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -67,6 +67,10 @@ type NotificationParams = {
   message: ReactNode
 }
 
+type AdditionalInformation = {
+  [x: string]: string | string[]
+}
+
 type Props = {
   createFeedback: (feedback: FeedbackInput) => void
   currentUser: UserOutput | null
@@ -74,6 +78,7 @@ type Props = {
   feedbackFailed: boolean
   feedbackSending: boolean
   createNotification: (params: NotificationParams) => void
+  additionalInformation?: AdditionalInformation
 }
 
 export function FeedbackWidget({
@@ -83,6 +88,7 @@ export function FeedbackWidget({
   feedbackFailed,
   feedbackSending,
   createNotification,
+  additionalInformation,
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
@@ -123,7 +129,28 @@ export function FeedbackWidget({
     setValue('feedbackType', openInput || OpenInput.Other)
     setValue('screenshot', screenshot || '')
     setValue('path', router.asPath || '')
-  }, [currentUser, openInput, screenshot, router.asPath, setValue])
+
+    if (additionalInformation) {
+      Object.keys(additionalInformation).forEach(key => {
+        const value = additionalInformation[key]
+
+        if (typeof value === 'string') {
+          setValue(key, value)
+        }
+
+        if (Array.isArray(value)) {
+          setValue(key, value.join(', '))
+        }
+      })
+    }
+  }, [
+    currentUser,
+    openInput,
+    screenshot,
+    router.asPath,
+    setValue,
+    additionalInformation,
+  ])
 
   const iconStyling = {
     size: openInput ? 16 : 40,
@@ -182,6 +209,19 @@ export function FeedbackWidget({
   function onSubmit(form: FeedbackInput): void {
     if (!currentUser) return
 
+    const formattedAdditionalInformation: AdditionalInformation = {}
+
+    if (additionalInformation) {
+      Object.keys(additionalInformation).forEach(key => {
+        const value = additionalInformation[key]
+        if (typeof value === 'string') {
+          formattedAdditionalInformation[key] = value
+        } else if (Array.isArray(value)) {
+          formattedAdditionalInformation[key] = value.join(', ')
+        }
+      })
+    }
+
     createFeedback({
       firstName: currentUser?.firstName,
       lastName: currentUser?.lastName,
@@ -190,6 +230,7 @@ export function FeedbackWidget({
       message: form.message,
       screenshot: screenshot || '',
       path: router.asPath,
+      ...formattedAdditionalInformation,
     })
   }
 

--- a/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
+++ b/packages/lib/src/components/FeedbackWidget/FeedbackWidget.tsx
@@ -229,7 +229,7 @@ export function FeedbackWidget({
       feedbackType: openInput || OpenInput.Other,
       message: form.message,
       screenshot: screenshot || '',
-      path: router.asPath,
+      path: router.asPath || '',
       ...formattedAdditionalInformation,
     })
   }
@@ -264,6 +264,7 @@ export function FeedbackWidget({
     <>
       <ActionIcon
         variant="filled"
+        aria-label={t('feedbackWidget.openButton.ariaLabel')}
         size="lg"
         radius="xl"
         style={{
@@ -439,6 +440,7 @@ export function FeedbackWidget({
                           <ActionIcon
                             variant={screenshot ? 'filled' : 'outline'}
                             size="md"
+                            aria-label={t('feedbackWidget.screenshot.label')}
                             onClick={() => {
                               setIsCapturingScreenshot(true)
                             }}

--- a/packages/lib/src/components/LoginForm/LoginForm.module.css
+++ b/packages/lib/src/components/LoginForm/LoginForm.module.css
@@ -21,11 +21,11 @@
   width: 400px;
 }
 
-.login-form__input-label {
-  font-weight: var(--mantine-font-weight-bold);
+.login-form__input-label--email {
 }
 
-.login-form__input-margin {
+.login-form__input-label--password {
+  font-weight: var(--mantine-font-weight-bold);
   margin-top: var(--mantine-spacing-xs);
 }
 

--- a/packages/lib/src/components/LoginForm/LoginForm.tsx
+++ b/packages/lib/src/components/LoginForm/LoginForm.tsx
@@ -95,7 +95,7 @@ export function LoginForm({
                     label={t('loginView.form.email')}
                     required
                     classNames={{
-                      label: classes['login-form__input-label'],
+                      root: classes['login-form__input-label--email'],
                     }}
                     withAsterisk
                   />
@@ -124,8 +124,7 @@ export function LoginForm({
                     label={t('loginView.form.password')}
                     required
                     classNames={{
-                      label: classes['login-form__input-label'],
-                      root: classes['login-form__input-margin'],
+                      root: classes['login-form__input-label--password'],
                     }}
                     withAsterisk
                   />

--- a/packages/types/src/feedback.ts
+++ b/packages/types/src/feedback.ts
@@ -8,7 +8,7 @@ export const OpenInput = {
 
 export type OpenInputTypeValues = (typeof OpenInput)[keyof typeof OpenInput]
 
-export const feedbackFormSchema = z.object({
+export const baseFeedbackFormSchema = z.object({
   firstName: z.string(),
   lastName: z.string(),
   email: z.string().email(),
@@ -17,6 +17,12 @@ export const feedbackFormSchema = z.object({
   screenshot: z.string(),
   path: z.string(),
 })
+
+export const additionalPropertiesSchema = z.string()
+
+export const feedbackFormSchema = baseFeedbackFormSchema.catchall(
+  additionalPropertiesSchema,
+)
 
 export type FeedbackInput = z.infer<typeof feedbackFormSchema>
 


### PR DESCRIPTION
## DESCRIPTION

In this PR the FeedbackWidget Component has been refactored. Now its possible to give an arbitrary number of key value pairs as prop to the FeedbackWidget. This customizable additional information will be added to the email to provide more context (e.g. user language, user roles, environment, software version etc.)

### TO-DO

- [x] implement and update tests
- [x] update docs and Migration Guide
- [x] pull `main` & resolve merge conflicts
- [ ] check Vercel deployment

### CLOSES

closes #554 
