### PR TITLE
refactor: indicate selected color theme in dropdown and icon

### DIFF
--- a/packages/app/src/pages/_app.tsx
+++ b/packages/app/src/pages/_app.tsx
@@ -20,6 +20,7 @@
 import '@mantine/core/styles.css'
 import '@mantine/spotlight/styles.css'
 
+import { COLOR_SCHEME } from '@frachtwerk/essencium-lib'
 import {
   createTheme,
   Loader,
@@ -151,7 +152,7 @@ function App({
       }),
   )
 
-  let systemColorScheme: MantineColorScheme = 'light'
+  let systemColorScheme: MantineColorScheme = COLOR_SCHEME.light
 
   const [colorScheme, setColorScheme] = useLocalStorage<MantineColorScheme>({
     key: 'mantine-color-scheme',
@@ -162,18 +163,23 @@ function App({
   if (typeof window !== 'undefined') {
     systemColorScheme = window.matchMedia('(prefers-color-scheme: light)')
       .matches
-      ? 'light'
-      : 'dark'
+      ? COLOR_SCHEME.light
+      : COLOR_SCHEME.dark
 
     window
       .matchMedia('(prefers-color-scheme: light)')
       .addEventListener('change', event => {
-        setColorScheme(event.matches ? 'light' : 'dark')
+        setColorScheme(event.matches ? COLOR_SCHEME.light : COLOR_SCHEME.dark)
       })
   }
 
   function toggleColorScheme(value?: MantineColorScheme): void {
-    setColorScheme(value || (colorScheme === 'dark' ? 'light' : 'dark'))
+    setColorScheme(
+      value ||
+        (colorScheme === COLOR_SCHEME.dark
+          ? COLOR_SCHEME.light
+          : COLOR_SCHEME.dark),
+    )
   }
 
   useHotkeys([['mod+J', () => toggleColorScheme()]])

--- a/packages/lib/src/components/Header/components/ThemeSelector/ThemeSelector.module.css
+++ b/packages/lib/src/components/Header/components/ThemeSelector/ThemeSelector.module.css
@@ -31,6 +31,18 @@
   }
 }
 
+.theme-selector__group--active {
+  @mixin light {
+    background-color: var(--mantine-color-gray-0);
+    color: var(--mantine-primary-color-6);
+  }
+
+  @mixin dark {
+    background-color: var(--mantine-color-gray-9);
+    color: var(--mantine-primary-color-2);
+  }
+}
+
 .theme-selector__button {
   padding: 0;
   background-color: transparent;
@@ -61,6 +73,16 @@
 
   @mixin dark {
     display: block;
+  }
+}
+
+.theme-selector__icon--active {
+  @mixin light {
+    color: var(--mantine-primary-color-6);
+  }
+
+  @mixin dark {
+    color: var(--mantine-primary-color-2);
   }
 }
 

--- a/packages/lib/src/components/Header/components/ThemeSelector/ThemeSelector.tsx
+++ b/packages/lib/src/components/Header/components/ThemeSelector/ThemeSelector.tsx
@@ -29,29 +29,31 @@ import {
 } from '@mantine/core'
 import { IconDeviceLaptop, IconMoon, IconSun } from '@tabler/icons-react'
 import { useTranslation } from 'next-i18next'
+import { useState } from 'react'
 
 import classes from './ThemeSelector.module.css'
 
-type Props = {
-  className?: {
-    iconSun?: string
-    iconMoon?: string
-  }
-}
+export const COLOR_SCHEME = {
+  light: 'light',
+  dark: 'dark',
+} as const
 
-export function ThemeSelector({ className }: Props): JSX.Element {
+export function ThemeSelector(): JSX.Element {
   const { t } = useTranslation()
 
-  const { setColorScheme } = useMantineColorScheme()
+  const { setColorScheme, colorScheme } = useMantineColorScheme()
 
-  let systemColorScheme: MantineColorScheme = 'light'
+  const [isSystemColorScheme, setIsSystemColorScheme] = useState(false)
+
+  let systemColorScheme: MantineColorScheme = COLOR_SCHEME.light
 
   if (typeof window !== 'undefined') {
     systemColorScheme = window.matchMedia('(prefers-color-scheme: light)')
       .matches
-      ? 'light'
-      : 'dark'
+      ? COLOR_SCHEME.light
+      : COLOR_SCHEME.dark
   }
+
   return (
     <Popover width={130} position="bottom" withArrow shadow="sm">
       <PopoverTarget>
@@ -62,13 +64,17 @@ export function ThemeSelector({ className }: Props): JSX.Element {
             <>
               <IconSun
                 className={`${classes['theme-selector__iconLight']} ${
-                  className?.iconSun ? className.iconSun : ''
+                  !isSystemColorScheme
+                    ? classes['theme-selector__icon--active']
+                    : ''
                 } `}
               />
 
               <IconMoon
                 className={`${classes['theme-selector__iconDark']} ${
-                  className?.iconMoon ? className.iconMoon : ''
+                  !isSystemColorScheme
+                    ? classes['theme-selector__icon--active']
+                    : ''
                 }`}
               />
             </>
@@ -79,9 +85,15 @@ export function ThemeSelector({ className }: Props): JSX.Element {
       <PopoverDropdown className={classes['theme-selector__popover-dropdown']}>
         <Group
           onClick={() => {
-            setColorScheme('light')
+            setColorScheme(COLOR_SCHEME.light)
+
+            setIsSystemColorScheme(false)
           }}
-          className={classes['theme-selector__group']}
+          className={
+            colorScheme === COLOR_SCHEME.light && !isSystemColorScheme
+              ? `${classes['theme-selector__group']} ${classes['theme-selector__group--active']}`
+              : classes['theme-selector__group']
+          }
         >
           <IconSun size={20} />
 
@@ -92,9 +104,15 @@ export function ThemeSelector({ className }: Props): JSX.Element {
 
         <Group
           onClick={() => {
-            setColorScheme('dark')
+            setColorScheme(COLOR_SCHEME.dark)
+
+            setIsSystemColorScheme(false)
           }}
-          className={classes['theme-selector__group']}
+          className={
+            colorScheme === COLOR_SCHEME.dark && !isSystemColorScheme
+              ? `${classes['theme-selector__group']} ${classes['theme-selector__group--active']}`
+              : classes['theme-selector__group']
+          }
         >
           <IconMoon size={20} />
 
@@ -106,8 +124,14 @@ export function ThemeSelector({ className }: Props): JSX.Element {
         <Group
           onClick={() => {
             setColorScheme(systemColorScheme)
+
+            setIsSystemColorScheme(true)
           }}
-          className={classes['theme-selector__group']}
+          className={
+            isSystemColorScheme
+              ? `${classes['theme-selector__group']} ${classes['theme-selector__group--active']}`
+              : classes['theme-selector__group']
+          }
         >
           <IconDeviceLaptop size={20} />
 

--- a/packages/lib/src/components/Translations/Translations.tsx
+++ b/packages/lib/src/components/Translations/Translations.tsx
@@ -48,6 +48,7 @@ import { FormEvent, useState } from 'react'
 import { KeyPath } from 'react-json-tree'
 
 import { hasRequiredRights } from '../../utils/hasRequiredRights'
+import { COLOR_SCHEME } from '../Header'
 import classes from './Translations.module.css'
 
 // dynamically load the JSONTree component to avoid SSR errors
@@ -242,7 +243,9 @@ export function Translations({
           <JSONTree
             hideRoot
             data={filteredTranslations}
-            theme={colorScheme === 'light' ? TREE_THEME : TREE_THEME_DARK}
+            theme={
+              colorScheme === COLOR_SCHEME.light ? TREE_THEME : TREE_THEME_DARK
+            }
             getItemString={() => null}
             labelRenderer={([key]) => (
               <Text


### PR DESCRIPTION
## DESCRIPTION

In this PR the following functionality has been added: 

* In the themeSelector dropdown the currently active theme is now indicated (via highlighted row and text-color)
* The themeSelector Icon is now displayed in the primary color, when the theme has been changed manually to dark or light. If the system theme is used, the icon is in a neutral color. 

### CLOSES

closes #492 
