### PR TITLE
refactor: make roles input configurable

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -1,5 +1,11 @@
 # Migrations
 
+## 7.4.0
+
+### `src/pages/users/[id].tsx`
+
+- `UserForm` Component now accepts a new optional prop "rolesEnabledForSsoUser" which is false by default. If set to `true`, the input field for roles in the userForm can be edited for user which are logged in via SSO.
+
 ## [7.3.0 (06.08.2024)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.2.0...essencium-app-v7.3.0)
 
 ### `src/pages/index.tsx`

--- a/packages/lib/src/components/User/UserForm.tsx
+++ b/packages/lib/src/components/User/UserForm.tsx
@@ -58,6 +58,7 @@ type Props = {
   setValue: UseFormSetValue<UserInput | UserUpdate>
   onSubmit: () => void
   isLoading: boolean
+  rolesEnabledForSsoUser?: boolean
 }
 
 export function UserForm({
@@ -68,6 +69,7 @@ export function UserForm({
   formState,
   onSubmit,
   isLoading,
+  rolesEnabledForSsoUser = false,
 }: Props): JSX.Element {
   const isSso = Boolean(ssoProvider && ssoProvider !== UserSource.LOCAL)
 
@@ -347,7 +349,7 @@ export function UserForm({
             render={({ field }) => (
               <MultiSelect
                 {...field}
-                disabled={isSso}
+                disabled={isSso && !rolesEnabledForSsoUser}
                 label={t('addUpdateUserView.form.role')}
                 data={rolesData}
                 withAsterisk


### PR DESCRIPTION
## DESCRIPTION

If a user account has been created via a sso provider, all input fields in the userForm were disabled by default. Therefor the roles of sso users could not be updated. 

In this PR the disabled prop for the roles input in the UserForm has been made configurable. The default is still disabled, but it can be enabled via prop. Since different projects can have different approaches regarding the roles update process it is helpful, if the input field for roles can be enabled, if needed. 

### TO-DO

- [X] implement and update tests
- [X] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #618 
