### PR TITLE
add support for sub nav items

### DIFF
--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -42,7 +42,6 @@ import {
   IconUserStar,
 } from '@tabler/icons-react'
 import { useAtom, useSetAtom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
 import Image from 'next/image'
 import { usePathname, useRouter } from 'next/navigation'
 import React, { useEffect, useState } from 'react'
@@ -150,9 +149,6 @@ export const SEARCH_ITEMS: SearchItems[] = [
   ...FOOTER_LINKS,
 ]
 
-const isFixedNavAtom = atomWithStorage('isFixedNav', false)
-const isFoldedNavAtom = atomWithStorage('isFoldedNav', true)
-
 export function AuthLayout({ children, ...props }: Props): JSX.Element | null {
   const router = useRouter()
 
@@ -160,9 +156,9 @@ export function AuthLayout({ children, ...props }: Props): JSX.Element | null {
 
   const [mobileNavBarOpened, { toggle: toggleMobileNavBar }] = useDisclosure()
 
-  const [isFoldedNav, setIsFoldedNav] = useAtom(isFoldedNavAtom)
+  const [isFoldedNav, setIsFoldedNav] = useState(false)
 
-  const [isFixedNav, setIsFixedNav] = useAtom(isFixedNavAtom)
+  const [isFixedNav, setIsFixedNav] = useState(true)
 
   const { data: user } = useGetMe()
 

--- a/packages/lib/src/components/NavBar/NavBar.tsx
+++ b/packages/lib/src/components/NavBar/NavBar.tsx
@@ -146,7 +146,7 @@ export function NavBar({
       </AppShellSection>
 
       <AppShellSection grow>
-        <NavLinks links={links} userRights={userRights} />
+        <NavLinks links={links} userRights={userRights} foldedNav={foldedNav} />
       </AppShellSection>
 
       <AppShellSection>

--- a/packages/lib/src/components/NavBar/components/NavLinks.module.css
+++ b/packages/lib/src/components/NavBar/components/NavLinks.module.css
@@ -25,3 +25,7 @@
   font-size: var(--mantine-font-size-sm);
   white-space: nowrap;
 }
+
+.nav-bar__navlink--sublink {
+  margin: 8px 0;
+}

--- a/packages/lib/src/components/NavBar/components/NavLinks.tsx
+++ b/packages/lib/src/components/NavBar/components/NavLinks.tsx
@@ -38,12 +38,8 @@ export function NavLinks({ links, userRights }: Props): JSX.Element {
 
   const pathname = usePathname()
 
-  function isLinkActive(path: string): boolean {
-    if (path === '/') {
-      return pathname === path
-    }
-
-    return pathname?.startsWith(path)
+  function isLinkActive(link: string): boolean {
+    return pathname.endsWith(link)
   }
 
   return (
@@ -62,7 +58,27 @@ export function NavLinks({ links, userRights }: Props): JSX.Element {
               root: classes['nav-bar__navlink--root'],
               label: classes['nav-bar__navlink--label'],
             }}
-          />
+          >
+            {link.navLinks?.map(sublink =>
+              !sublink.rights.length ||
+              (sublink.rights &&
+                hasRequiredRights(userRights, sublink.rights)) ? (
+                <MantineNavLink
+                  component={NextLink}
+                  key={sublink.label}
+                  href={`${link.to}${sublink.to}`}
+                  leftSection={sublink.icon}
+                  label={t(sublink.label)}
+                  active={isLinkActive(sublink.to)}
+                  className={classes['nav-bar__navlink--sublink']}
+                  classNames={{
+                    root: classes['nav-bar__navlink--root'],
+                    label: classes['nav-bar__navlink--label'],
+                  }}
+                />
+              ) : null,
+            )}
+          </MantineNavLink>
         ) : null,
       )}
     </Stack>

--- a/packages/lib/src/components/NavBar/components/NavLinks.tsx
+++ b/packages/lib/src/components/NavBar/components/NavLinks.tsx
@@ -42,6 +42,10 @@ export function NavLinks({ links, userRights }: Props): JSX.Element {
     return pathname.endsWith(link)
   }
 
+  function isSubLinkActive(sublinks: NavLink[] = []): boolean {
+    return sublinks.some(sublink => isLinkActive(sublink.to))
+  }
+
   return (
     <Stack gap="md">
       {links.map(link =>
@@ -53,7 +57,8 @@ export function NavLinks({ links, userRights }: Props): JSX.Element {
             href={link.to}
             leftSection={link.icon}
             label={t(link.label)}
-            active={isLinkActive(link.to)}
+            active={isLinkActive(link.to) || isSubLinkActive(link.navLinks)}
+            color={isLinkActive(link.to) ? undefined : 'gray'}
             classNames={{
               root: classes['nav-bar__navlink--root'],
               label: classes['nav-bar__navlink--label'],
@@ -66,7 +71,7 @@ export function NavLinks({ links, userRights }: Props): JSX.Element {
                 <MantineNavLink
                   component={NextLink}
                   key={sublink.label}
-                  href={`${link.to}${sublink.to}`}
+                  href={`${link.to === '/' ? '' : link.to}${sublink.to}`}
                   leftSection={sublink.icon}
                   label={t(sublink.label)}
                   active={isLinkActive(sublink.to)}

--- a/packages/lib/src/components/NavBar/components/NavLinks.tsx
+++ b/packages/lib/src/components/NavBar/components/NavLinks.tsx
@@ -31,9 +31,10 @@ import classes from './NavLinks.module.css'
 type Props = {
   links: NavLink[]
   userRights?: string[] | null
+  foldedNav: boolean
 }
 
-export function NavLinks({ links, userRights }: Props): JSX.Element {
+export function NavLinks({ links, userRights, foldedNav }: Props): JSX.Element {
   const { t } = useTranslation()
 
   const pathname = usePathname()
@@ -64,25 +65,27 @@ export function NavLinks({ links, userRights }: Props): JSX.Element {
               label: classes['nav-bar__navlink--label'],
             }}
           >
-            {link.navLinks?.map(sublink =>
-              !sublink.rights.length ||
-              (sublink.rights &&
-                hasRequiredRights(userRights, sublink.rights)) ? (
-                <MantineNavLink
-                  component={NextLink}
-                  key={sublink.label}
-                  href={`${link.to === '/' ? '' : link.to}${sublink.to}`}
-                  leftSection={sublink.icon}
-                  label={t(sublink.label)}
-                  active={isLinkActive(sublink.to)}
-                  className={classes['nav-bar__navlink--sublink']}
-                  classNames={{
-                    root: classes['nav-bar__navlink--root'],
-                    label: classes['nav-bar__navlink--label'],
-                  }}
-                />
-              ) : null,
-            )}
+            {!foldedNav
+              ? link.navLinks?.map(sublink =>
+                  !sublink.rights.length ||
+                  (sublink.rights &&
+                    hasRequiredRights(userRights, sublink.rights)) ? (
+                    <MantineNavLink
+                      component={NextLink}
+                      key={sublink.label}
+                      href={`${link.to === '/' ? '' : link.to}${sublink.to}`}
+                      leftSection={sublink.icon}
+                      label={t(sublink.label)}
+                      active={isLinkActive(sublink.to)}
+                      className={classes['nav-bar__navlink--sublink']}
+                      classNames={{
+                        root: classes['nav-bar__navlink--root'],
+                        label: classes['nav-bar__navlink--label'],
+                      }}
+                    />
+                  ) : null,
+                )
+              : null}
           </MantineNavLink>
         ) : null,
       )}

--- a/packages/types/src/navbar.ts
+++ b/packages/types/src/navbar.ts
@@ -18,10 +18,11 @@
  */
 
 export type NavLink = {
-  icon: JSX.Element
+  icon?: JSX.Element
   label: string
   color: string
   to: string
   description?: string
   rights: (string | string[])[]
+  navLinks?: NavLink[]
 }


### PR DESCRIPTION
## DESCRIPTION

This PR adds support for sub menu items, by appending a recursive `navItems` array inside a nav item.

### TO-DO

- [x] implement and update tests
- [x] update docs
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment
