### PR TITLE
fix: set screenshot type optinal

### DIFF
--- a/packages/types/src/feedback.ts
+++ b/packages/types/src/feedback.ts
@@ -14,7 +14,7 @@ export const baseFeedbackFormSchema = z.object({
   email: z.string().email(),
   feedbackType: z.enum([OpenInput.Issue, OpenInput.Idea, OpenInput.Other]),
   message: z.string({ required_error: 'feedbackWidget.requiredError' }).min(10),
-  screenshot: z.string(),
+  screenshot: z.string().optional(),
   path: z.string(),
 })
 


### PR DESCRIPTION
## DESCRIPTION

This PR makes the `screenshot` property optional.

### TO-DO

- [x] implement and update tests
- [x] update docs
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment
