### PR TITLE
fix: fix pathname in RouteProtector

### DIFF
--- a/packages/app/src/app/[locale]/(main)/layout.tsx
+++ b/packages/app/src/app/[locale]/(main)/layout.tsx
@@ -22,11 +22,12 @@ import { RouteProtector } from '@/components/RouteProtector'
 
 type Props = {
   children: React.ReactNode
+  params: { locale: string }
 }
 
-export default function MainLayout({ children }: Props): JSX.Element {
+export default function MainLayout({ children, params }: Props): JSX.Element {
   return (
-    <RouteProtector>
+    <RouteProtector params={params}>
       <AuthLayout>{children}</AuthLayout>
     </RouteProtector>
   )

--- a/packages/app/src/app/[locale]/page.tsx
+++ b/packages/app/src/app/[locale]/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata(
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function page({ params }: Props): JSX.Element {
   return (
-    <RouteProtector>
+    <RouteProtector params={params}>
       <AuthLayout>
         <HomeView />
       </AuthLayout>

--- a/packages/app/src/components/RouteProtector.tsx
+++ b/packages/app/src/components/RouteProtector.tsx
@@ -7,14 +7,17 @@ import { usePathname, useRouter } from 'next/navigation'
 import { useTranslation } from 'react-i18next'
 
 import { userRightsAtom } from '@/api'
+import { i18nConfig } from '@/config'
 
 import { AuthLayout, NAV_LINKS } from './layouts'
 import classes from './RouteProtector.module.css'
 
 export function RouteProtector({
   children,
+  params,
 }: {
   children: React.ReactNode
+  params: { locale: string }
 }): JSX.Element | null {
   const pathname = usePathname()
 
@@ -22,7 +25,14 @@ export function RouteProtector({
 
   const { t } = useTranslation()
 
-  const route = NAV_LINKS.find(navLink => navLink.to === `${pathname}`)
+  const { locale } = params
+
+  const pathnameToFind =
+    locale === i18nConfig.defaultLocale
+      ? pathname
+      : `/${pathname.split(`/${locale}/`)[1]}`
+
+  const route = NAV_LINKS.find(navLink => navLink.to === pathnameToFind)
 
   const userRights = useAtomValue(userRightsAtom)
 


### PR DESCRIPTION
## DESCRIPTION

Since the pathname also contains the locale (if it is not the defaultLocale), the locale needs to be removed in order to check for the respective page rights.

**Testing:** 
* Login in with devnull_user@frachtwerk.de
* Go to /users or /roles 
* RouterProtector should be rendered correctly
* Change language and test again 

### TO-DO

- [X] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #644 
