### PR TITLE
Add password strength meter to user profile

### DIFF
--- a/packages/app/public/locales/de/common.json
+++ b/packages/app/public/locales/de/common.json
@@ -116,8 +116,12 @@
             "number": "Mindestens eine Zahl",
             "lowercase": "Mindestens ein Kleinbuchstabe",
             "uppercase": "Mindestens ein Großbuchstabe",
-            "special": "Mindestens ein Sonderzeichen",
-            "length": "Mindestens {{passwordLength}} Zeichen lang"
+            "specialCharacter": "Mindestens ein Sonderzeichen",
+            "length": "Mindestens {{passwordLength}} Zeichen lang",
+            "requirements": {
+              "met": "Anforderungen erfüllt",
+              "unmet": "Anforderungen nicht erfüllt"
+            }
           }
         }
       }

--- a/packages/app/public/locales/de/common.json
+++ b/packages/app/public/locales/de/common.json
@@ -110,6 +110,14 @@
             "newPassword": "Neues Passwort",
             "confirmNewPassword": "Neues Passwort bestätigen",
             "savePassword": "Passwort speichern"
+          },
+          "passwordStrength": {
+            "validationError": "Passwort entspricht nicht den Anforderungen",
+            "number": "Mindestens eine Zahl",
+            "lowercase": "Mindestens ein Kleinbuchstabe",
+            "uppercase": "Mindestens ein Großbuchstabe",
+            "special": "Mindestens ein Sonderzeichen",
+            "length": "Mindestens {{passwordLength}} Zeichen lang"
           }
         }
       }

--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -110,6 +110,14 @@
             "newPassword": "New Password",
             "confirmNewPassword": "Confirm New Password",
             "savePassword": "Save Password"
+          },
+          "passwordStrength": {
+            "validationError": "Password does not meet the requirements",
+            "number": "At least one number",
+            "lowercase": "At least one lowercase letter",
+            "uppercase": "At least one uppercase letter",
+            "special": "At least one special character",
+            "length": "At least {{passwordLength}} characters"
           }
         }
       }

--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -116,8 +116,12 @@
             "number": "At least one number",
             "lowercase": "At least one lowercase letter",
             "uppercase": "At least one uppercase letter",
-            "special": "At least one special character",
-            "length": "At least {{passwordLength}} characters"
+            "specialCharacter": "At least one special character",
+            "length": "At least {{passwordLength}} characters",
+            "requirements": {
+              "met": "Requirements met",
+              "unmet": "Requirements not met"
+            }
           }
         }
       }

--- a/packages/app/src/app/[locale]/(main)/rights/RightsView.tsx
+++ b/packages/app/src/app/[locale]/(main)/rights/RightsView.tsx
@@ -31,6 +31,7 @@ import {
   RightOutput,
   RIGHTS,
   RoleOutput,
+  ROLES,
   RoleUpdate,
 } from '@frachtwerk/essencium-types'
 import { Button, Checkbox, Flex, Text, Title } from '@mantine/core'
@@ -155,7 +156,7 @@ export default function RightsView(): JSX.Element {
           }
 
           if (
-            role.name === 'ADMIN' ||
+            role.name === ROLES.ADMIN ||
             role.protected ||
             !hasRequiredRights(userRights, [
               RIGHTS.ROLE_UPDATE,

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
@@ -92,6 +92,7 @@ export function ProfileDataCard({
             <PasswordChangeForm
               handlePasswordUpdate={handlePasswordUpdate}
               isLoading={isUpdatingPassword}
+              isAdmin={!!user.roles.find(role => role.name === 'ADMIN')}
             />
           </Tabs.Panel>
         )}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/ProfileDataCard.tsx
@@ -19,6 +19,7 @@
 
 import {
   PasswordChange,
+  ROLES,
   UserOutput,
   UserUpdate,
 } from '@frachtwerk/essencium-types'
@@ -92,7 +93,9 @@ export function ProfileDataCard({
             <PasswordChangeForm
               handlePasswordUpdate={handlePasswordUpdate}
               isLoading={isUpdatingPassword}
-              isAdmin={!!user.roles.find(role => role.name === 'ADMIN')}
+              isAdmin={Boolean(
+                user.roles.find(role => role.name === ROLES.ADMIN),
+              )}
             />
           </Tabs.Panel>
         )}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
@@ -20,10 +20,9 @@
 'use client'
 
 import {
-  PasswordChangeAdmin,
+  PasswordChange,
   passwordChangeSchemaAdmin,
   passwordChangeSchemaUser,
-  PasswordChangeUser,
   PasswordStrengthRules,
 } from '@frachtwerk/essencium-types'
 import {
@@ -45,8 +44,8 @@ import { PasswordRequirement } from './PasswordRequirement'
 
 type Props = {
   handlePasswordUpdate: (
-    oldPassword: PasswordChangeUser['password'],
-    newPassword: PasswordChangeUser['password'],
+    oldPassword: PasswordChange['password'],
+    newPassword: PasswordChange['password'],
   ) => void
   isLoading: boolean
   isAdmin: boolean
@@ -98,7 +97,7 @@ export function PasswordChangeForm({
     },
   })
 
-  function onSubmit(data: PasswordChangeUser | PasswordChangeAdmin): void {
+  function onSubmit(data: PasswordChange): void {
     handlePasswordUpdate(data.password, data.verification)
   }
 

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
@@ -20,13 +20,11 @@
 'use client'
 
 import {
-  lowerCaseRegex,
-  numberRegex,
-  PasswordChange,
+  PasswordChangeAdmin,
   passwordChangeSchemaAdmin,
   passwordChangeSchemaUser,
-  specialCharacterRegex,
-  upperCaseRegex,
+  PasswordChangeUser,
+  PasswordStrengthRules,
 } from '@frachtwerk/essencium-types'
 import {
   Box,
@@ -38,7 +36,7 @@ import {
   Text,
 } from '@mantine/core'
 import { useTranslation } from 'next-i18next'
-import { useMemo, useState } from 'react'
+import { useState } from 'react'
 import { Controller } from 'react-hook-form'
 
 import { useZodForm } from '../../../../../hooks'
@@ -47,15 +45,15 @@ import { PasswordRequirement } from './PasswordRequirement'
 
 type Props = {
   handlePasswordUpdate: (
-    oldPassword: PasswordChange['password'],
-    newPassword: PasswordChange['password'],
+    oldPassword: PasswordChangeUser['password'],
+    newPassword: PasswordChangeUser['password'],
   ) => void
   isLoading: boolean
   isAdmin: boolean
 }
 
 type PasswordRequirementType = {
-  id: number
+  id: string
   requirement: RegExp
   label: string
 }[]
@@ -71,46 +69,25 @@ export function PasswordChangeForm({
 
   const [passwordValue, setPasswordValue] = useState<string | null>(null)
 
-  const passwordRequirements: PasswordRequirementType = useMemo(() => {
-    return [
-      {
-        id: 1,
-        requirement: isAdmin ? /.{20,}/ : /.{12,}/,
+  const passwordRequirements: PasswordRequirementType = [
+    ...Object.entries(PasswordStrengthRules).map(([key, value]) => {
+      return {
+        id: key,
+        requirement: value,
         label: t(
-          'profileView.dataCard.tabs.passwordChange.passwordStrength.length',
-          { passwordLength: isAdmin ? 20 : 12 },
+          `profileView.dataCard.tabs.passwordChange.passwordStrength.${key}`,
         ),
-      },
-      {
-        id: 2,
-        requirement: lowerCaseRegex,
-        label: t(
-          'profileView.dataCard.tabs.passwordChange.passwordStrength.lowercase',
-        ),
-      },
-      {
-        id: 3,
-        requirement: upperCaseRegex,
-        label: t(
-          'profileView.dataCard.tabs.passwordChange.passwordStrength.uppercase',
-        ),
-      },
-      {
-        id: 4,
-        requirement: specialCharacterRegex,
-        label: t(
-          'profileView.dataCard.tabs.passwordChange.passwordStrength.special',
-        ),
-      },
-      {
-        id: 5,
-        requirement: numberRegex,
-        label: t(
-          'profileView.dataCard.tabs.passwordChange.passwordStrength.number',
-        ),
-      },
-    ]
-  }, [isAdmin, t])
+      }
+    }),
+    {
+      id: 'length',
+      requirement: isAdmin ? /.{20,}/ : /.{12,}/,
+      label: t(
+        'profileView.dataCard.tabs.passwordChange.passwordStrength.length',
+        { passwordLength: isAdmin ? 20 : 12 },
+      ),
+    },
+  ]
 
   const { handleSubmit, control, formState } = useZodForm({
     schema: isAdmin ? passwordChangeSchemaAdmin : passwordChangeSchemaUser,
@@ -121,7 +98,7 @@ export function PasswordChangeForm({
     },
   })
 
-  function onSubmit(data: PasswordChange): void {
+  function onSubmit(data: PasswordChangeUser | PasswordChangeAdmin): void {
     handlePasswordUpdate(data.password, data.verification)
   }
 

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordChangeForm.tsx
@@ -48,7 +48,7 @@ type Props = {
     newPassword: PasswordChange['password'],
   ) => void
   isLoading: boolean
-  isAdmin: boolean
+  isAdmin?: boolean
 }
 
 type PasswordRequirementType = {

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordRequirement.module.css
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordRequirement.module.css
@@ -1,0 +1,9 @@
+.color {
+  color: var(--mantine-color-dark);
+  transition: color 0.5s ease;
+}
+
+.color-validated {
+  color: var(--mantine-color-green-7);
+  transition: color 0.5s ease;
+}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordRequirement.test.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordRequirement.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { MantineProvider } from '@mantine/core'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { PasswordRequirement } from './PasswordRequirement'
+
+describe('PasswordRequirement.tsx', () => {
+  it('should the correct label, color and icon if requirement is met', async () => {
+    const renderedComponent = render(
+      <MantineProvider>
+        <PasswordRequirement meets label="label 1" />
+      </MantineProvider>,
+    )
+
+    const label = screen.getByText('label 1')
+
+    expect(label).toBeDefined()
+
+    expect(label.classList).toContain('_color-validated_fdffd1')
+
+    expect(
+      screen.getByLabelText(
+        'profileView.dataCard.tabs.passwordChange.passwordStrength.requirements.met',
+      ),
+    ).toBeDefined()
+
+    renderedComponent.unmount()
+  })
+
+  it('should render the correct label, color and icon if requirement is not met', async () => {
+    const renderedComponent = render(
+      <MantineProvider>
+        <PasswordRequirement meets={false} label="label 1" />
+      </MantineProvider>,
+    )
+
+    const label = screen.getByText('label 1')
+
+    expect(label).toBeDefined()
+
+    expect(label.classList).toContain('_color_fdffd1')
+
+    expect(
+      screen.getByLabelText(
+        'profileView.dataCard.tabs.passwordChange.passwordStrength.requirements.unmet',
+      ),
+    ).toBeDefined()
+
+    renderedComponent.unmount()
+  })
+})

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordRequirement.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordRequirement.tsx
@@ -1,0 +1,34 @@
+import { Group, Text } from '@mantine/core'
+import { IconCircleCheck, IconCircleX } from '@tabler/icons-react'
+
+import classes from './PasswordRequirement.module.css'
+
+type Props = {
+  meets: boolean
+  label: string
+}
+
+export function PasswordRequirement({ meets, label }: Props): JSX.Element {
+  return (
+    <Group mt="xs" gap="xs">
+      {meets ? (
+        <IconCircleCheck
+          size={20}
+          className={meets ? classes['color-validated'] : classes.color}
+        />
+      ) : (
+        <IconCircleX
+          size={20}
+          className={meets ? classes['color-validated'] : classes.color}
+        />
+      )}
+
+      <Text
+        size="sm"
+        className={meets ? classes['color-validated'] : classes.color}
+      >
+        {label}
+      </Text>
+    </Group>
+  )
+}

--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordRequirement.tsx
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PasswordRequirement.tsx
@@ -1,5 +1,25 @@
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 import { Group, Text } from '@mantine/core'
 import { IconCircleCheck, IconCircleX } from '@tabler/icons-react'
+import { useTranslation } from 'react-i18next'
 
 import classes from './PasswordRequirement.module.css'
 
@@ -9,17 +29,25 @@ type Props = {
 }
 
 export function PasswordRequirement({ meets, label }: Props): JSX.Element {
+  const { t } = useTranslation()
+
   return (
     <Group mt="xs" gap="xs">
       {meets ? (
         <IconCircleCheck
           size={20}
           className={meets ? classes['color-validated'] : classes.color}
+          aria-label={t(
+            'profileView.dataCard.tabs.passwordChange.passwordStrength.requirements.met',
+          )}
         />
       ) : (
         <IconCircleX
           size={20}
           className={meets ? classes['color-validated'] : classes.color}
+          aria-label={t(
+            'profileView.dataCard.tabs.passwordChange.passwordStrength.requirements.unmet',
+          )}
         />
       )}
 

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -94,19 +94,21 @@ export const userUpdateSchema = userOutputSchema
 
 export type UserUpdate = z.infer<typeof userUpdateSchema>
 
-export const upperCaseRegex = /[A-Z]/
-export const lowerCaseRegex = /[a-z]/
-export const numberRegex = /[0-9]/
-export const specialCharacterRegex = /[!@#§$%^&*(),.?":{}|<>[\]\\';'/`~+=_-]/
+export const PasswordStrengthRules = {
+  uppercase: /[A-Z]/,
+  lowercase: /[a-z]/,
+  number: /[0-9]/,
+  specialCharacter: /[!@#§$%^&*(),.?":{}|<>[\]\\';'/`~+=_-]/,
+} as const
 
 const passwordStrengthBaseSchema = z
   .string()
   .refine(
     password =>
-      upperCaseRegex.test(password) &&
-      lowerCaseRegex.test(password) &&
-      numberRegex.test(password) &&
-      specialCharacterRegex.test(password),
+      PasswordStrengthRules.uppercase.test(password) &&
+      PasswordStrengthRules.lowercase.test(password) &&
+      PasswordStrengthRules.number.test(password) &&
+      PasswordStrengthRules.specialCharacter.test(password),
     {
       message:
         'profileView.dataCard.tabs.passwordChange.passwordStrength.validationError',
@@ -145,7 +147,7 @@ export const passwordChangeSchemaUser = passwordChangeBaseSchema
     path: ['confirmPassword'],
   })
 
-export type PasswordChange = z.infer<typeof passwordChangeSchemaUser>
+export type PasswordChangeUser = z.infer<typeof passwordChangeSchemaUser>
 
 export const passwordChangeSchemaAdmin = passwordChangeBaseSchema
   .extend({

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -147,7 +147,7 @@ export const passwordChangeSchemaUser = passwordChangeBaseSchema
     path: ['confirmPassword'],
   })
 
-export type PasswordChangeUser = z.infer<typeof passwordChangeSchemaUser>
+export type PasswordChange = z.infer<typeof passwordChangeSchemaUser>
 
 export const passwordChangeSchemaAdmin = passwordChangeBaseSchema
   .extend({

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -94,18 +94,69 @@ export const userUpdateSchema = userOutputSchema
 
 export type UserUpdate = z.infer<typeof userUpdateSchema>
 
-export const passwordChangeSchema = z
-  .object({
-    verification: z.string().min(8, 'validation.password.minLength'),
-    password: z.string().min(8, 'validation.password.minLength'),
-    confirmPassword: z.string().min(8, 'validation.password.minLength'),
+export const upperCaseRegex = /[A-Z]/
+export const lowerCaseRegex = /[a-z]/
+export const numberRegex = /[0-9]/
+export const specialCharacterRegex = /[!@#§$%^&*(),.?":{}|<>[\]\\';'/`~+=_-]/
+
+const passwordStrengthBaseSchema = z
+  .string()
+  .refine(
+    password =>
+      upperCaseRegex.test(password) &&
+      lowerCaseRegex.test(password) &&
+      numberRegex.test(password) &&
+      specialCharacterRegex.test(password),
+    {
+      message:
+        'profileView.dataCard.tabs.passwordChange.passwordStrength.validationError',
+    },
+  )
+
+const passwordStrengthSchemaUser = passwordStrengthBaseSchema.and(
+  z
+    .string()
+    .min(
+      12,
+      'profileView.dataCard.tabs.passwordChange.passwordStrength.validationError',
+    ),
+)
+
+const passwordStrengthSchemaAdmin = passwordStrengthBaseSchema.and(
+  z
+    .string()
+    .min(
+      20,
+      'profileView.dataCard.tabs.passwordChange.passwordStrength.validationError',
+    ),
+)
+
+const passwordChangeBaseSchema = z.object({
+  verification: z.string(),
+  confirmPassword: z.string(),
+})
+
+export const passwordChangeSchemaUser = passwordChangeBaseSchema
+  .extend({
+    password: passwordStrengthSchemaUser,
   })
   .refine(data => data.password === data.confirmPassword, {
     message: 'validation.password.confirmError',
     path: ['confirmPassword'],
   })
 
-export type PasswordChange = z.infer<typeof passwordChangeSchema>
+export type PasswordChange = z.infer<typeof passwordChangeSchemaUser>
+
+export const passwordChangeSchemaAdmin = passwordChangeBaseSchema
+  .extend({
+    password: passwordStrengthSchemaAdmin,
+  })
+  .refine(data => data.password === data.confirmPassword, {
+    message: 'validation.password.confirmError',
+    path: ['confirmPassword'],
+  })
+
+export type PasswordChangeAdmin = z.infer<typeof passwordChangeSchemaAdmin>
 
 export const loginFormSchema = z.object({
   email: z.string().email('validation.email.notValid'),


### PR DESCRIPTION
## DESCRIPTION

In this PR a component has been added to the changePassword tab in the user profile. It indicates whether the necessary requirements for new passwords are met.

The requirements currently are:

* min length 12 char, for admins 20 char
* min 1 upper case letter
* min 1 lower case letter
* min 1 symbol
* min 1 number


### CLOSES

closes #653 
