### PR TITLE
fix: error message overlap on profile page in mobile view

### DIFF
--- a/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.module.css
+++ b/packages/lib/src/components/Profile/components/ProfileDataCard/components/PersonalDataForm.module.css
@@ -24,12 +24,12 @@
 }
 
 .personal-data-form__stack {
-  min-width: 45%;
+  width: 45%;
 }
 
 .personal-data-form__error-box {
   margin-top: -0.6rem;
-  height: 0.8rem;
+  height: 1.8rem;
 }
 
 .personal-data-form__error-text {


### PR DESCRIPTION
## DESCRIPTION

This merge request fixes the layout issue on the profile page in mobile view, where error messages for first name and last name overlapped with phone number and mobile number labels.
