### PR TITLE
Refactor version and env indicator

### DIFF
--- a/packages/app/.env
+++ b/packages/app/.env
@@ -4,7 +4,7 @@
 APP_URL=http://localhost:3000
 NEXT_PUBLIC_APP_URL=https://staging.essencium.dev
 
-API_URL=https://essencium-tagged.staging.dev.frachtwerk.de
+API_URL=https://backend.staging.essencium.dev
 NEXT_PUBLIC_API_URL=https://backend.staging.essencium.dev
 
 OAUTH_REDIRECT_URI=http://localhost:3000

--- a/packages/app/public/runtimeConfig.js
+++ b/packages/app/public/runtimeConfig.js
@@ -3,10 +3,10 @@
 window['runtimeConfig'] = {
   required: {
     API_URL: '<API_URL>',
-    APP_ENV: '<APP_ENV>',
     APP_URL: '<APP_URL>',
   },
   optional: {
     OAUTH_REDIRECT_URI: '<OAUTH_REDIRECT_URI>',
+    APP_ENV: '<APP_ENV>',
   },
 }

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -50,12 +50,21 @@ import { useTranslation } from 'react-i18next'
 
 import { useGetMe, userAtom, userRightsAtom } from '@/api'
 import { useCreateFeedback } from '@/api/feedback'
-import { logout, withBaseStylingShowNotification } from '@/utils'
+import {
+  isBrowserEnvironment,
+  logout,
+  withBaseStylingShowNotification,
+} from '@/utils'
 
 import packageJson from '../../../package.json'
 import classes from './AuthLayout.module.css'
 
 const version = packageJson?.version ? packageJson.version : undefined
+
+const environment =
+  isBrowserEnvironment() && !process.env.NEXT_PUBLIC_DISABLE_INSTRUMENTATION
+    ? window?.runtimeConfig?.optional?.APP_ENV
+    : undefined
 
 type Props = AppShellProps & {
   children: React.ReactNode
@@ -276,6 +285,7 @@ export function AuthLayout({ children, ...props }: Props): JSX.Element | null {
             user={user}
             isOpen={mobileNavBarOpened}
             handleOpenNav={toggleMobileNavBar}
+            environment={environment}
           />
 
           <NavBar

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -55,12 +55,7 @@ import { logout, withBaseStylingShowNotification } from '@/utils'
 import packageJson from '../../../package.json'
 import classes from './AuthLayout.module.css'
 
-const version =
-  packageJson.version &&
-  process.env.NEXT_PUBLIC_SHOW_VERSION &&
-  process.env.NEXT_PUBLIC_SHOW_VERSION === '1'
-    ? packageJson.version
-    : undefined
+const version = packageJson?.version ? packageJson.version : undefined
 
 type Props = AppShellProps & {
   children: React.ReactNode

--- a/packages/app/src/instrumentation.ts
+++ b/packages/app/src/instrumentation.ts
@@ -13,11 +13,11 @@ export async function register(): Promise<void> {
     } = {
       required: {
         API_URL: `${process.env.API_URL}`,
-        APP_ENV: `${process.env.APP_ENV}`,
         APP_URL: `${process.env.APP_URL}`,
       },
       optional: {
         OAUTH_REDIRECT_URI: `${process.env.OAUTH_REDIRECT_URI}`,
+        APP_ENV: `${process.env.APP_ENV}`,
       },
     } as const
 

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -5,11 +5,11 @@ declare global {
     runtimeConfig: {
       required: {
         API_URL: string
-        APP_ENV: string
         APP_URL: string
       }
       optional: {
         OAUTH_REDIRECT_URI: string
+        APP_ENV: string
       }
     }
   }

--- a/packages/lib/src/components/Footer/Footer.tsx
+++ b/packages/lib/src/components/Footer/Footer.tsx
@@ -62,11 +62,7 @@ export function Footer({
 
           <Text> {t('footer.license')} </Text>
 
-          {version || process.env.NEXT_PUBLIC_ENV ? (
-            <Code>{`${version || ''} ${
-              process.env.NEXT_PUBLIC_ENV || ''
-            }`}</Code>
-          ) : null}
+          {version && <Code>{version}</Code>}
         </Flex>
 
         <Flex direction="row" gap="lg" align="center">

--- a/packages/lib/src/components/Header/Header.module.css
+++ b/packages/lib/src/components/Header/Header.module.css
@@ -32,3 +32,12 @@
 .header__burger {
   z-index: 200;
 }
+
+.environment-indicator {
+  margin-right: 20px;
+  overflow: visible;
+}
+
+.environment-indicator__text {
+  text-transform: uppercase;
+}

--- a/packages/lib/src/components/Header/Header.tsx
+++ b/packages/lib/src/components/Header/Header.tsx
@@ -24,6 +24,7 @@ import {
   AppShellHeader,
   AppShellHeaderProps,
   Burger,
+  Code,
   Flex,
   Group,
   useMantineTheme,
@@ -36,12 +37,14 @@ type Props = AppShellHeaderProps & {
   user: UserOutput | undefined
   isOpen: boolean
   handleOpenNav: () => void
+  environment: string | undefined
 }
 
 export function Header({
   user,
   isOpen,
   handleOpenNav,
+  environment,
   ...props
 }: Props): JSX.Element {
   const theme = useMantineTheme()
@@ -73,7 +76,15 @@ export function Header({
 
         <SearchBar />
 
-        <Group wrap="nowrap">
+        <Group wrap="nowrap" justify="space-between">
+          {environment && (
+            <Code className={classes['environment-indicator']}>
+              <span className={classes['environment-indicator__text']}>
+                {environment}
+              </span>
+            </Code>
+          )}
+
           <Group wrap="nowrap">
             <ThemeSelector />
           </Group>


### PR DESCRIPTION
## DESCRIPTION

This PR refactors the version and environment indicator. The version is now always shown inside the footer and derived from the project `package.json`.  The environment is implemented inside the runtime config and visualized inside the header component beside the theme switcher.

### TO-DO

- [x] implement and update tests
- [x] update docs
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes _list of issues closed in this PR_
