### PR TITLE
fix: remove handle refetch that causes duplicate requests

### DIFF
--- a/packages/app/src/app/[locale]/(main)/admin/rights/RightsView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/rights/RightsView.tsx
@@ -254,7 +254,6 @@ export default function RightsView(): JSX.Element {
             pageSize={pageSize}
             setActivePage={setActivePage}
             setPageSize={setPageSize}
-            handleRefetch={handleRefetch}
           />
         </>
       )}

--- a/packages/app/src/app/[locale]/(main)/admin/roles/RolesView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/roles/RolesView.tsx
@@ -376,7 +376,6 @@ export default function RolesView(): JSX.Element {
             pageSize={pageSize}
             setActivePage={setActivePage}
             setPageSize={setPageSize}
-            handleRefetch={handleRefetch}
           />
         </>
       )}

--- a/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
@@ -449,7 +449,6 @@ export default function UsersView(): JSX.Element {
               pageSize={pageSize}
               setActivePage={setActivePage}
               setPageSize={setPageSize}
-              handleRefetch={handleRefetch}
             />
           </>
         )}

--- a/packages/lib/src/components/TablePagination/TablePagination.test.tsx
+++ b/packages/lib/src/components/TablePagination/TablePagination.test.tsx
@@ -110,7 +110,6 @@ describe('TablePagination.tsx', () => {
     activePage: 1,
     setPageSize: vi.fn(),
     setActivePage: vi.fn(),
-    handleRefetch: vi.fn(),
   }
 
   it('should render page select and pagination', () => {
@@ -159,7 +158,6 @@ describe('TablePagination.tsx', () => {
             activePage={mockedProps.activePage}
             setPageSize={mockedProps.setPageSize}
             setActivePage={mockedProps.setActivePage}
-            handleRefetch={mockedProps.handleRefetch}
             fixedTablePageSize={2}
           />
         </AppShell>

--- a/packages/lib/src/components/TablePagination/TablePagination.tsx
+++ b/packages/lib/src/components/TablePagination/TablePagination.tsx
@@ -36,7 +36,6 @@ type Props<T> = CustomPaginationProps & {
   activePage: PaginatedResponse<T>['number']
   setPageSize: (pageSize: PaginatedResponse<T>['size']) => void
   setActivePage: (activePage: PaginatedResponse<T>['number']) => void
-  handleRefetch: () => void
   fixedTablePageSize?: number
   jumpToLimit?: number
   pageSizeOptions?: string[]
@@ -49,7 +48,6 @@ export function TablePagination<T>({
   activePage,
   setPageSize,
   setActivePage,
-  handleRefetch,
   fixedTablePageSize,
   jumpToLimit = 50,
   pageSizeOptions = ['10', '20', '30', '40', '50', '100'],
@@ -77,7 +75,6 @@ export function TablePagination<T>({
       enteredPageAsNumber <= (table ? table.getPageCount() : pageCount ?? 1)
     ) {
       setActivePage(enteredPageAsNumber)
-      handleRefetch()
     }
   }
 
@@ -107,8 +104,6 @@ export function TablePagination<T>({
 
                 setPageSize(Number(e))
                 setActivePage(1)
-
-                handleRefetch()
               }}
             />
           </>
@@ -120,7 +115,6 @@ export function TablePagination<T>({
         value={activePage}
         onChange={e => {
           setActivePage(e)
-          handleRefetch()
         }}
         {...props}
       />


### PR DESCRIPTION
## DESCRIPTION

This PR fixes the bug where the request on page change for table views is fired twice due to invoking `handleRefetch` and the re-rendering of the affected component which as well causes a refetch. Hence, the manual `handleRefetch` callback is not necessary.

This will be breaking for essenciun-based projects.

### TO-DO

- [x] implement and update tests
- [x] update docs
- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment