### PR TITLE
fix: show buttons depending on rights on home page

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -4,7 +4,7 @@
 
 ### `src/app/[locale]/main/HomeView.tsx:`
 
-- check for right `USER_READ` and hand down prop `showUserButtonRight` to `Home.tsx`
+- check for right `USER_READ` and hand down prop `showUsersPageButton` to `Home.tsx`
 
 ## [7.9.1 (16.01.2025)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.9.0...essencium-app-v7.9.1)
 

--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -1,5 +1,11 @@
 # Migrations
 
+## 7.10.0
+
+### `src/app/[locale]/main/HomeView.tsx:`
+
+- check for right `USER_READ` and hand down prop `showUserButtonRight` to `Home.tsx`
+
 ## [7.9.1 (16.01.2025)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.9.0...essencium-app-v7.9.1)
 
 - `handleRefetch` prop in `TablePagination.tsx` was removed, means all references of `TablePagination.tsx` needs to be adjusted by removing the handler prop

--- a/packages/app/src/app/[locale]/(main)/HomeView.tsx
+++ b/packages/app/src/app/[locale]/(main)/HomeView.tsx
@@ -19,16 +19,29 @@
 
 'use client'
 
-import { Home } from '@frachtwerk/essencium-lib'
+import { hasRequiredRights, Home } from '@frachtwerk/essencium-lib'
+import { RIGHTS } from '@frachtwerk/essencium-types'
+import { useAtomValue } from 'jotai'
 import { useRouter } from 'next/navigation'
 import type { JSX } from 'react'
 
+import { userRightsAtom } from '@/api'
+
 export default function HomeView(): JSX.Element {
   const router = useRouter()
+
+  const userRights = useAtomValue(userRightsAtom)
 
   function handleButtonClick(path: string): void {
     router.push(path)
   }
 
-  return <Home onClickButton={handleButtonClick} />
+  const showUserButtonRight = hasRequiredRights(userRights, RIGHTS.USER_READ)
+
+  return (
+    <Home
+      onClickButton={handleButtonClick}
+      showUserButtonRight={showUserButtonRight}
+    />
+  )
 }

--- a/packages/app/src/app/[locale]/(main)/HomeView.tsx
+++ b/packages/app/src/app/[locale]/(main)/HomeView.tsx
@@ -36,12 +36,12 @@ export default function HomeView(): JSX.Element {
     router.push(path)
   }
 
-  const showUserButtonRight = hasRequiredRights(userRights, RIGHTS.USER_READ)
+  const showUsersPageButton = hasRequiredRights(userRights, RIGHTS.USER_READ)
 
   return (
     <Home
       onClickButton={handleButtonClick}
-      showUserButtonRight={showUserButtonRight}
+      showUsersPageButton={showUsersPageButton}
     />
   )
 }

--- a/packages/lib/src/components/Home/Home.tsx
+++ b/packages/lib/src/components/Home/Home.tsx
@@ -28,12 +28,12 @@ import classes from './Home.module.css'
 
 type Props = {
   onClickButton: (path: string) => void
-  showUserButtonRight?: boolean
+  showUsersPageButton: boolean
 }
 
 export function Home({
   onClickButton,
-  showUserButtonRight,
+  showUsersPageButton,
 }: Props): JSX.Element {
   const { t } = useTranslation()
 
@@ -66,7 +66,7 @@ export function Home({
             {t('homeView.action.search')}
           </Button>
 
-          {showUserButtonRight ? (
+          {showUsersPageButton ? (
             <Button
               onClick={() => onClickButton('/admin/users')}
               variant="outline"

--- a/packages/lib/src/components/Home/Home.tsx
+++ b/packages/lib/src/components/Home/Home.tsx
@@ -28,9 +28,13 @@ import classes from './Home.module.css'
 
 type Props = {
   onClickButton: (path: string) => void
+  showUserButtonRight?: boolean
 }
 
-export function Home({ onClickButton }: Props): JSX.Element {
+export function Home({
+  onClickButton,
+  showUserButtonRight,
+}: Props): JSX.Element {
   const { t } = useTranslation()
 
   return (
@@ -62,14 +66,16 @@ export function Home({ onClickButton }: Props): JSX.Element {
             {t('homeView.action.search')}
           </Button>
 
-          <Button
-            onClick={() => onClickButton('/admin/users')}
-            variant="outline"
-            leftSection={<IconUsers />}
-            fullWidth
-          >
-            {t('homeView.action.users')}
-          </Button>
+          {showUserButtonRight ? (
+            <Button
+              onClick={() => onClickButton('/admin/users')}
+              variant="outline"
+              leftSection={<IconUsers />}
+              fullWidth
+            >
+              {t('homeView.action.users')}
+            </Button>
+          ) : null}
 
           <Button
             onClick={() => onClickButton('/profile')}


### PR DESCRIPTION
## DESCRIPTION

The following was implemented in this PR: 
The `USER_READ` right is checked on the `HomeView` in order to render the button for the `UserView`.

### TO-DO

- [x] update MIGRATON.md
- [X] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #668 
