### PR TITLE
fix: fix role name in tableHeader of RightsView

### DIFF
--- a/packages/app/src/app/[locale]/(main)/admin/rights/RightsView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/rights/RightsView.tsx
@@ -143,7 +143,7 @@ export default function RightsView(): JSX.Element {
         size: 100,
         header: () => (
           <Text inherit c={role.protected ? 'grey' : 'primary'}>
-            {t(`rightsView.table.${role.name}`)}
+            {role.name}
           </Text>
         ),
         enableSorting: false,


### PR DESCRIPTION
## DESCRIPTION

In the Tableheader on the RightsView page the name of the role is displayed instead of a translation. 

### TO-DO

- [X] pull `main` & resolve merge conflicts
- [X] check Vercel deployment

### CLOSES

closes #660 
