### PR TITLE
chore: add DEFAULT_USER_EMAIL env for undeletable default user

### DIFF
--- a/packages/app/.env
+++ b/packages/app/.env
@@ -9,6 +9,9 @@ NEXT_PUBLIC_API_URL=https://backend.staging.essencium.dev
 
 OAUTH_REDIRECT_URI=http://localhost:3000
 
+DEFAULT_USER_EMAIL=
+NEXT_PUBLIC_DEFAULT_USER_EMAIL=
+
 APP_ENV=development # development | acceptance | staging
 
 # Next.js

--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -10,6 +10,14 @@
 
 - update route and refresh router
 
+### `.env`
+
+- add new env variables `DEFAULT_USER_EMAIL` and `NEXT_PUBLIC_DEFAULT_USER_EMAIL`
+
+### `src/app/[locale]/(main)/admin/users/UsersView.tsx`
+
+- check for undeletable default user by using email from env variables `DEFAULT_USER_EMAIL` or `NEXT_PUBLIC_DEFAULT_USER_EMAIL` instead of the default username
+
 ## [7.10.0 (23.01.2025)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.9.1...essencium-app-v7.10.0)
 
 ### `src/app/[locale]/(main)/HomeView.tsx`

--- a/packages/app/public/runtimeConfig.example.js
+++ b/packages/app/public/runtimeConfig.example.js
@@ -7,6 +7,7 @@ window['runtimeConfig'] = {
   },
   optional: {
     OAUTH_REDIRECT_URI: 'http://localhost:3000',
+    DEFAULT_USER_EMAIL: '<DEFAULT_USER_EMAIL>',
     APP_ENV: 'development',
   },
 }

--- a/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
@@ -104,6 +104,10 @@ export default function UsersView(): JSX.Element {
 
   const userRights = useAtomValue(userRightsAtom)
 
+  const defaultUserEmail = process.env.NEXT_PUBLIC_DISABLE_INSTRUMENTATION
+    ? process.env.NEXT_PUBLIC_DEFAULT_USER_EMAIL
+    : window?.runtimeConfig?.optional?.DEFAULT_USER_EMAIL
+
   const { t } = useTranslation()
 
   const [deleteModalOpened, deleteModalHandlers] = useDisclosure(false)
@@ -274,7 +278,7 @@ export default function UsersView(): JSX.Element {
         cell: info => {
           const rowUser = info.row.original
 
-          const isDefaultUser = rowUser.firstName === 'Admin'
+          const isDefaultUser = rowUser.email === defaultUserEmail
 
           return (
             <Flex direction="row" gap="xs">
@@ -340,7 +344,14 @@ export default function UsersView(): JSX.Element {
         size: 120,
       },
     ],
-    [t, handleEditUser, userRights, handleInvalidateToken, deleteModalHandlers],
+    [
+      t,
+      handleEditUser,
+      userRights,
+      defaultUserEmail,
+      handleInvalidateToken,
+      deleteModalHandlers,
+    ],
   )
 
   const table = useReactTable({

--- a/packages/app/src/instrumentation.ts
+++ b/packages/app/src/instrumentation.ts
@@ -22,6 +22,7 @@ export async function register(): Promise<void> {
       },
       optional: {
         OAUTH_REDIRECT_URI: `${process.env.OAUTH_REDIRECT_URI}`,
+        DEFAULT_USER_EMAIL: `${process.env.DEFAULT_USER_EMAIL}`,
         APP_ENV: `${process.env.APP_ENV}`,
       },
     } as const

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -9,6 +9,7 @@ declare global {
       }
       optional: {
         OAUTH_REDIRECT_URI: string
+        DEFAULT_USER_EMAIL: string
         APP_ENV: string
       }
     }


### PR DESCRIPTION
## DESCRIPTION

The initial admin user should be protected and not be deleteable in the UI. Currently the defaultUser is defined by the name. This should be changed to the email. The email should be configurable via the runtimeConfig.

- add DEFAULT_USER_EMAIL and NEXT_PUBLIC_DEFAULT_USER_EMAIL env for undeletable default user

