### PR TITLE
fix: fix vulnerability vitest

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -79,7 +79,7 @@
     "postcss-preset-mantine": "1.17.0",
     "prettier": "3.0.3",
     "vite": "5.4.14",
-    "vitest": "2.1.8"
+    "vitest": "2.1.9"
   },
   "engines": {
     "node": ">=20",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -67,7 +67,7 @@
     "@typescript-eslint/eslint-plugin": "7.18.0",
     "@typescript-eslint/parser": "7.18.0",
     "@vitejs/plugin-react": "4.2.1",
-    "@vitest/coverage-v8": "2.1.8",
+    "@vitest/coverage-v8": "2.1.9",
     "axios": "1.7.9",
     "dayjs": "1.11.13",
     "eslint": "8.56.0",
@@ -103,7 +103,7 @@
     "tslib": "2.5.3",
     "typescript": "5.7.3",
     "vite": "5.4.14",
-    "vitest": "2.1.8",
+    "vitest": "2.1.9",
     "zod": "3.22.5"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -272,8 +272,8 @@ importers:
         specifier: 5.4.14
         version: 5.4.14(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
       vitest:
-        specifier: 2.1.8
-        version: 2.1.8(@types/node@20.11.30)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
+        specifier: 2.1.9
+        version: 2.1.9(@types/node@20.11.30)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
 
   packages/eslint-config:
     dependencies:
@@ -411,8 +411,8 @@ importers:
         specifier: 4.2.1
         version: 4.2.1(vite@5.4.14(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))
       '@vitest/coverage-v8':
-        specifier: 2.1.8
-        version: 2.1.8(vitest@2.1.8(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))
+        specifier: 2.1.9
+        version: 2.1.9(vitest@2.1.9(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))
       axios:
         specifier: 1.7.9
         version: 1.7.9
@@ -519,8 +519,8 @@ importers:
         specifier: 5.4.14
         version: 5.4.14(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
       vitest:
-        specifier: 2.1.8
-        version: 2.1.8(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
+        specifier: 2.1.9
+        version: 2.1.9(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
       zod:
         specifier: 3.22.5
         version: 3.22.5
@@ -1662,20 +1662,20 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0
 
-  '@vitest/coverage-v8@2.1.8':
-    resolution: {integrity: sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==}
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
     peerDependencies:
-      '@vitest/browser': 2.1.8
-      vitest: 2.1.8
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@2.1.8':
-    resolution: {integrity: sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==}
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
-  '@vitest/mocker@2.1.8':
-    resolution: {integrity: sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==}
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0
@@ -1685,20 +1685,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.1.8':
-    resolution: {integrity: sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==}
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
-  '@vitest/runner@2.1.8':
-    resolution: {integrity: sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==}
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
-  '@vitest/snapshot@2.1.8':
-    resolution: {integrity: sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==}
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
 
-  '@vitest/spy@2.1.8':
-    resolution: {integrity: sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==}
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
-  '@vitest/utils@2.1.8':
-    resolution: {integrity: sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==}
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
@@ -4370,8 +4370,8 @@ packages:
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
-  vite-node@2.1.8:
-    resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
@@ -4406,15 +4406,15 @@ packages:
       terser:
         optional: true
 
-  vitest@2.1.8:
-    resolution: {integrity: sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==}
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@types/node': ^18.0.0 || >=20.0.0
-      '@vitest/browser': 2.1.8
-      '@vitest/ui': 2.1.8
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
       happy-dom: '*'
       jsdom: '*'
     peerDependenciesMeta:
@@ -5668,7 +5668,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))':
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -5682,55 +5682,55 @@ snapshots:
       std-env: 3.8.0
       test-exclude: 7.0.1
       tinyrainbow: 1.2.0
-      vitest: 2.1.8(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
+      vitest: 2.1.9(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@2.1.8':
+  '@vitest/expect@2.1.9':
     dependencies:
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
       chai: 5.1.2
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.8(vite@5.4.14(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))':
+  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))':
     dependencies:
-      '@vitest/spy': 2.1.8
+      '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.14
     optionalDependencies:
       vite: 5.4.14(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
 
-  '@vitest/mocker@2.1.8(vite@5.4.14(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))':
+  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))':
     dependencies:
-      '@vitest/spy': 2.1.8
+      '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.14
     optionalDependencies:
       vite: 5.4.14(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
 
-  '@vitest/pretty-format@2.1.8':
+  '@vitest/pretty-format@2.1.9':
     dependencies:
       tinyrainbow: 1.2.0
 
-  '@vitest/runner@2.1.8':
+  '@vitest/runner@2.1.9':
     dependencies:
-      '@vitest/utils': 2.1.8
+      '@vitest/utils': 2.1.9
       pathe: 1.1.2
 
-  '@vitest/snapshot@2.1.8':
+  '@vitest/snapshot@2.1.9':
     dependencies:
-      '@vitest/pretty-format': 2.1.8
+      '@vitest/pretty-format': 2.1.9
       magic-string: 0.30.14
       pathe: 1.1.2
 
-  '@vitest/spy@2.1.8':
+  '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
 
-  '@vitest/utils@2.1.8':
+  '@vitest/utils@2.1.9':
     dependencies:
-      '@vitest/pretty-format': 2.1.8
+      '@vitest/pretty-format': 2.1.9
       loupe: 3.1.2
       tinyrainbow: 1.2.0
 
@@ -8698,7 +8698,7 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  vite-node@2.1.8(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0):
+  vite-node@2.1.9(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
@@ -8716,7 +8716,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.8(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0):
+  vite-node@2.1.9(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0):
     dependencies:
       cac: 6.7.14
       debug: 4.3.7
@@ -8756,15 +8756,15 @@ snapshots:
       sugarss: 4.0.1(postcss@8.4.49)
       terser: 5.36.0
 
-  vitest@2.1.8(@types/node@20.11.30)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0):
+  vitest@2.1.9(@types/node@20.11.30)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0):
     dependencies:
-      '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.14(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))
-      '@vitest/pretty-format': 2.1.8
-      '@vitest/runner': 2.1.8
-      '@vitest/snapshot': 2.1.8
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
       chai: 5.1.2
       debug: 4.3.7
       expect-type: 1.1.0
@@ -8776,7 +8776,7 @@ snapshots:
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
       vite: 5.4.14(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
-      vite-node: 2.1.8(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
+      vite-node: 2.1.9(@types/node@20.11.30)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.11.30
@@ -8792,15 +8792,15 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.8(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0):
+  vitest@2.1.9(@types/node@20.14.14)(happy-dom@15.10.8)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0):
     dependencies:
-      '@vitest/expect': 2.1.8
-      '@vitest/mocker': 2.1.8(vite@5.4.14(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))
-      '@vitest/pretty-format': 2.1.8
-      '@vitest/runner': 2.1.8
-      '@vitest/snapshot': 2.1.8
-      '@vitest/spy': 2.1.8
-      '@vitest/utils': 2.1.8
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
       chai: 5.1.2
       debug: 4.3.7
       expect-type: 1.1.0
@@ -8812,7 +8812,7 @@ snapshots:
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
       vite: 5.4.14(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
-      vite-node: 2.1.8(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
+      vite-node: 2.1.9(@types/node@20.14.14)(sugarss@4.0.1(postcss@8.4.49))(terser@5.36.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.14.14


### PR DESCRIPTION
## DESCRIPTION

Patch vitest version to 2.1.9 and fix vulnerability.

### TO-DO

- [x] fix vulnerability

### CLOSES

closes https://github.com/Frachtwerk/essencium-frontend/security/dependabot/96
