### PR TITLE
Persist target page in url when session token expires

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -18,6 +18,10 @@
 
 - check for undeletable default user by using email from env variables `DEFAULT_USER_EMAIL` or `NEXT_PUBLIC_DEFAULT_USER_EMAIL` instead of the default username
 
+### `src/app/api/api.ts`
+
+- adjust redirect when user is unauthorized
+
 ## [7.10.0 (23.01.2025)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.9.1...essencium-app-v7.10.0)
 
 ### `src/app/[locale]/(main)/HomeView.tsx`

--- a/packages/app/src/api/api.ts
+++ b/packages/app/src/api/api.ts
@@ -124,7 +124,9 @@ api.interceptors.response.use(
     if (error?.response?.status === 401) {
       logout()
 
-      if (window.location.pathname !== '/login') window.location.href = '/login'
+      if (window.location.pathname !== '/login') {
+        window.location.href = `/login?redirect=${window.location.pathname}`
+      }
     }
 
     throw error


### PR DESCRIPTION
## DESCRIPTION

If the session token expires or is terminated, the user is automatically logged out when navigating the site. 
Now the target page is persisted in the URL so that the user lands directly on the desired page again after logging in again.

### TO-DO

- [X] pull `main` & resolve merge conflicts
- [X] check Vercel deployment

### CLOSES

closes #715 
