### PR TITLE
beautify 'active' state in user table 

### DIFF
--- a/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
@@ -198,9 +198,9 @@ export default function UsersView(): JSX.Element {
         header: () => <Text inherit>{t('usersView.table.active')}</Text>,
         cell: info =>
           info.getValue() ? (
-            <IconUserCheck color="#2f9e44" />
+            <IconUserCheck color="var(--mantine-color-green-8)" />
           ) : (
-            <IconUserX color="#e03131" />
+            <IconUserX color="var(--mantine-color-red-8)" />
           ),
         size: 80,
         enableColumnFilter: false,

--- a/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
@@ -47,13 +47,13 @@ import {
 } from '@mantine/core'
 import { useDebouncedValue, useDisclosure } from '@mantine/hooks'
 import {
-  IconCheck,
   IconDotsVertical,
   IconLogout,
   IconPencil,
   IconTrash,
+  IconUserCheck,
   IconUsers,
-  IconX,
+  IconUserX,
 } from '@tabler/icons-react'
 import {
   ColumnDef,
@@ -196,7 +196,12 @@ export default function UsersView(): JSX.Element {
       {
         accessorKey: 'enabled',
         header: () => <Text inherit>{t('usersView.table.active')}</Text>,
-        cell: info => (info.getValue() ? <IconCheck /> : <IconX />),
+        cell: info =>
+          info.getValue() ? (
+            <IconUserCheck color="#2f9e44" />
+          ) : (
+            <IconUserX color="#e03131" />
+          ),
         size: 80,
         enableColumnFilter: false,
       },


### PR DESCRIPTION
## DESCRIPTION

The active column can be enhanced visually with a more appealing indicator, such as a custom icon or different color scheme, to make it stand out.

### TO-DO

- [ ] change icon

### CLOSES

[665](https://github.com/Frachtwerk/essencium-frontend/issues/665)
