### PR TITLE
651 add datenschutz privacy policy and impressum legal notice pages

### DIFF
--- a/packages/app/public/locales/de/common.json
+++ b/packages/app/public/locales/de/common.json
@@ -323,6 +323,13 @@
       "text": "Wollen Sie diese Rolle wirklich löschen?"
     }
   },
+  "legalNoticeView": {
+    "title": "Impressum",
+    "companyInformation": "Angaben gemäß § 5 TMG",
+    "regulatoryAuthority": "Aufsichtsbehörde",
+    "dsiclaimer": "Haftungsausschluss",
+    "copyright": "Urheberrecht"
+  },
   "validation": {
     "email": {
       "notValid": "E-Mail ist nicht gültig"

--- a/packages/app/public/locales/de/common.json
+++ b/packages/app/public/locales/de/common.json
@@ -330,6 +330,14 @@
     "dsiclaimer": "Haftungsausschluss",
     "copyright": "Urheberrecht"
   },
+  "privacyPolicyView": {
+    "title": "Datenschutz",
+    "introduction": "Einleitung",
+    "dataCollection": "Datenerhebung",
+    "dataUsage": "Datenverwendung",
+    "dataProtection": "Datenschutz",
+    "contactInformation": "Kontaktinformationen"
+  },
   "validation": {
     "email": {
       "notValid": "E-Mail ist nicht gültig"

--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -330,6 +330,14 @@
     "dsiclaimer": "Disclaimer",
     "copyright": "Copyright"
   },
+  "privacyPolicyView": {
+    "title": "Privacy Policy",
+    "introduction": "introduction",
+    "dataCollection": "Data Collection",
+    "dataUsage": "Data Usage",
+    "dataProtection": "Data Protection",
+    "contactInformation": "Contact Information"
+  },
   "validation": {
     "email": {
       "notValid": "E-Mail is not valid"

--- a/packages/app/public/locales/en/common.json
+++ b/packages/app/public/locales/en/common.json
@@ -323,6 +323,13 @@
       "text": "Are you sure you want to delete this role?"
     }
   },
+  "legalNoticeView": {
+    "title": "Legal Notice",
+    "companyInformation": "Information according to § 5 TMG",
+    "regulatoryAuthority": "Regulatory Authority",
+    "dsiclaimer": "Disclaimer",
+    "copyright": "Copyright"
+  },
   "validation": {
     "email": {
       "notValid": "E-Mail is not valid"

--- a/packages/app/src/app/[locale]/(main)/legal-notice/LegalNoticeView.module.css
+++ b/packages/app/src/app/[locale]/(main)/legal-notice/LegalNoticeView.module.css
@@ -3,6 +3,6 @@
     box-shadow: var(--mantine-shadow-sm);
     border-radius: var(--mantine-radius-md);
     max-width: 800px;
-    margin: 0 auto;
+    margin: 12px auto;
   }
   

--- a/packages/app/src/app/[locale]/(main)/legal-notice/LegalNoticeView.module.css
+++ b/packages/app/src/app/[locale]/(main)/legal-notice/LegalNoticeView.module.css
@@ -1,0 +1,8 @@
+.legal-notice-card {
+    padding: var(--mantine-spacing-lg);
+    box-shadow: var(--mantine-shadow-sm);
+    border-radius: var(--mantine-radius-md);
+    max-width: 800px;
+    margin: 0 auto;
+  }
+  

--- a/packages/app/src/app/[locale]/(main)/legal-notice/LegalNoticeView.tsx
+++ b/packages/app/src/app/[locale]/(main)/legal-notice/LegalNoticeView.tsx
@@ -39,16 +39,16 @@ export default function LegalNoticeView(): JSX.Element {
         <Text>Frachtwerk GmbH</Text>
         <Text>Leopoldstraße 7C</Text>
         <Text>76133 Karlsruhe</Text>
-        <Text>Deutschland</Text>
-        <Text>Telefon: +49 (0) 721/1234567</Text>
-        <Text>E-Mail: info@frachtwerk.de</Text>
-        <Text>Geschäftsführer: Max Mustermann</Text>
+        <Text>Germany</Text>
+        <Text>Phone: +49 (0) 721/1234567</Text>
+        <Text>Email: info@frachtwerk.de</Text>
+        <Text>Managing Director: Max Mustermann</Text>
         <Divider />
 
         {/* Regulatory Authority (if any) */}
         <Title order={2}>{t('legalNoticeView.regulatoryAuthority')}</Title>
         <Text>
-          Beispielaufsichtsbehörde <br />
+          Example Regulatory Authority <br />
           Musterstraße 1 <br />
           12345 Musterstadt
         </Text>
@@ -57,20 +57,20 @@ export default function LegalNoticeView(): JSX.Element {
         {/* Disclaimer */}
         <Title order={2}>{t('legalNoticeView.dsiclaimer')}</Title>
         <Text>
-          Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung
-          für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten
-          sind ausschließlich deren Betreiber verantwortlich.
+          Despite careful review of content, we assume no liability for the
+          content of external links. The providers of the linked pages are
+          solely responsible for their content.
         </Text>
         <Divider />
 
         {/* Copyright / Legal Notice */}
         <Title order={2}>{t('legalNoticeView.copyright')}</Title>
         <Text>
-          Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen
-          Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung,
-          Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der
-          Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des
-          jeweiligen Autors bzw. Erstellers.
+          The content and works created by the site operators on these pages are
+          subject to German copyright law. Reproduction, processing,
+          distribution and any form of commercialization beyond the scope of
+          copyright law require the written consent of the respective author or
+          creator.
         </Text>
       </Stack>
     </Card>

--- a/packages/app/src/app/[locale]/(main)/legal-notice/LegalNoticeView.tsx
+++ b/packages/app/src/app/[locale]/(main)/legal-notice/LegalNoticeView.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Card, Divider, Stack, Text, Title } from '@mantine/core'
+import type { JSX } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import classes from './LegalNoticeView.module.css'
+
+export default function LegalNoticeView(): JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <Card withBorder className={classes['legal-notice-card']}>
+      <Stack gap="lg">
+        <Title order={1}>{t('legalNoticeView.title')}</Title>
+        <Divider />
+
+        {/* Company Information */}
+        <Title order={2}>{t('legalNoticeView.companyInformation')}</Title>
+        <Text>Frachtwerk GmbH</Text>
+        <Text>Leopoldstraße 7C</Text>
+        <Text>76133 Karlsruhe</Text>
+        <Text>Deutschland</Text>
+        <Text>Telefon: +49 (0) 721/1234567</Text>
+        <Text>E-Mail: info@frachtwerk.de</Text>
+        <Text>Geschäftsführer: Max Mustermann</Text>
+        <Divider />
+
+        {/* Regulatory Authority (if any) */}
+        <Title order={2}>{t('legalNoticeView.regulatoryAuthority')}</Title>
+        <Text>
+          Beispielaufsichtsbehörde <br />
+          Musterstraße 1 <br />
+          12345 Musterstadt
+        </Text>
+        <Divider />
+
+        {/* Disclaimer */}
+        <Title order={2}>{t('legalNoticeView.dsiclaimer')}</Title>
+        <Text>
+          Trotz sorgfältiger inhaltlicher Kontrolle übernehmen wir keine Haftung
+          für die Inhalte externer Links. Für den Inhalt der verlinkten Seiten
+          sind ausschließlich deren Betreiber verantwortlich.
+        </Text>
+        <Divider />
+
+        {/* Copyright / Legal Notice */}
+        <Title order={2}>{t('legalNoticeView.copyright')}</Title>
+        <Text>
+          Die durch die Seitenbetreiber erstellten Inhalte und Werke auf diesen
+          Seiten unterliegen dem deutschen Urheberrecht. Die Vervielfältigung,
+          Bearbeitung, Verbreitung und jede Art der Verwertung außerhalb der
+          Grenzen des Urheberrechtes bedürfen der schriftlichen Zustimmung des
+          jeweiligen Autors bzw. Erstellers.
+        </Text>
+      </Stack>
+    </Card>
+  )
+}

--- a/packages/app/src/app/[locale]/(main)/legal-notice/page.tsx
+++ b/packages/app/src/app/[locale]/(main)/legal-notice/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from 'next'
+import type { JSX } from 'react'
+
+import initTranslations from '@/config/i18n'
+
+import LegalNoticeView from './LegalNoticeView'
+
+type Props = {
+  params: Promise<{ locale: string }>
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params
+  const { locale } = params
+
+  const { t } = await initTranslations(locale)
+
+  return {
+    title: t('legalNoticeView.title'),
+  }
+}
+
+export default async function page(): Promise<JSX.Element> {
+  return <LegalNoticeView />
+}

--- a/packages/app/src/app/[locale]/(main)/privacy-policy/PrivacyPolicyView.module.css
+++ b/packages/app/src/app/[locale]/(main)/privacy-policy/PrivacyPolicyView.module.css
@@ -3,5 +3,5 @@
   box-shadow: var(--mantine-shadow-sm);
   border-radius: var(--mantine-radius-md);
   max-width: 800px;
-  margin: 0 auto;
+  margin: 12px auto;
 }

--- a/packages/app/src/app/[locale]/(main)/privacy-policy/PrivacyPolicyView.module.css
+++ b/packages/app/src/app/[locale]/(main)/privacy-policy/PrivacyPolicyView.module.css
@@ -1,0 +1,7 @@
+.privacy-policy-card {
+  padding: var(--mantine-spacing-lg);
+  box-shadow: var(--mantine-shadow-sm);
+  border-radius: var(--mantine-radius-md);
+  max-width: 800px;
+  margin: 0 auto;
+}

--- a/packages/app/src/app/[locale]/(main)/privacy-policy/PrivacyPolicyView.tsx
+++ b/packages/app/src/app/[locale]/(main)/privacy-policy/PrivacyPolicyView.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+/*
+ * Copyright (C) 2023 Frachtwerk GmbH, Leopoldstraße 7C, 76133 Karlsruhe.
+ *
+ * This file is part of Essencium Frontend.
+ *
+ * Essencium Frontend is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Essencium Frontend is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Card, Divider, Stack, Text, Title } from '@mantine/core'
+import type { JSX } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import classes from './PrivacyPolicyView.module.css'
+
+export default function PrivacyPolicyView(): JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <Card withBorder className={classes['privacy-policy-card']}>
+      <Stack gap="lg">
+        {/* Header */}
+        <Title order={1}>{t('privacyPolicyView.title')}</Title>
+        <Divider />
+
+        {/* Introduction */}
+        <Title order={2}>{t('privacyPolicyView.introduction')}</Title>
+        <Text>
+          This Privacy Policy explains how our company collects, uses, and
+          protects your personal data. We are committed to ensuring that your
+          privacy is protected. In this policy, you will find details about how
+          we handle your information.
+        </Text>
+        <Divider />
+
+        {/* Data Collection */}
+        <Title order={2}>{t('privacyPolicyView.dataCollection')}</Title>
+        <Text>
+          We collect information that you provide directly to us, such as when
+          you create an account, subscribe to our newsletter, or contact us with
+          inquiries. This may include your name, email address, phone number,
+          and other personal details.
+        </Text>
+        <Divider />
+
+        {/* Data Usage */}
+        <Title order={2}>{t('privacyPolicyView.dataUsage')}</Title>
+        <Text>
+          The data we collect is used to improve our services, maintain our
+          website, and communicate with you. We may use your information to
+          personalize your experience and inform you of updates or new services
+          that we offer.
+        </Text>
+        <Divider />
+
+        {/* Data Protection */}
+        <Title order={2}>{t('privacyPolicyView.dataProtection')}</Title>
+        <Text>
+          We implement a variety of security measures to ensure the safety of
+          your personal data. These measures include secure data storage,
+          encryption, and regular security reviews. Our data protection
+          practices comply with current legal standards.
+        </Text>
+        <Divider />
+
+        {/* Contact Information */}
+        <Title order={2}>{t('privacyPolicyView.contactInformation')}</Title>
+        <Text>
+          If you have any questions about this Privacy Policy or wish to
+          exercise your rights regarding your personal data, please contact us
+          at:
+          <br />
+          Email: privacy@frachtwerk.de
+          <br />
+          Phone: +49 (0) 721/7654321
+        </Text>
+      </Stack>
+    </Card>
+  )
+}

--- a/packages/app/src/app/[locale]/(main)/privacy-policy/page.tsx
+++ b/packages/app/src/app/[locale]/(main)/privacy-policy/page.tsx
@@ -1,0 +1,25 @@
+import { Metadata } from 'next'
+import type { JSX } from 'react'
+
+import initTranslations from '@/config/i18n'
+
+import PrivacyPolicy from './PrivacyPolicyView'
+
+type Props = {
+  params: Promise<{ locale: string }>
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const params = await props.params
+  const { locale } = params
+
+  const { t } = await initTranslations(locale)
+
+  return {
+    title: t('privacyPolicy.title'),
+  }
+}
+
+export default async function page(): Promise<JSX.Element> {
+  return <PrivacyPolicy />
+}

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -142,11 +142,11 @@ export const FOOTER_LINKS: NavLink[] = [
     rights: [],
   },
   {
-    icon: <IconSectionSign size={20} />,
     color: theme.primaryColor,
-    label: 'footer.imprint.label',
-    to: '/',
-    description: 'footer.imprint.description',
+    label: 'legalNoticeView.title',
+    icon: <IconSectionSign size={20} />,
+    to: '/legal-notice',
+    description: 'footer.legalNotice.description',
     rights: [],
   },
   {

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -136,9 +136,8 @@ export const FOOTER_LINKS: NavLink[] = [
   {
     icon: <IconShieldLock size={20} />,
     color: theme.primaryColor,
-    label: 'footer.privacy.label',
-    to: '/',
-    description: 'footer.privacy.description',
+    label: 'privacyPolicyView.title',
+    to: '/privacy-policy',
     rights: [],
   },
   {
@@ -146,7 +145,6 @@ export const FOOTER_LINKS: NavLink[] = [
     label: 'legalNoticeView.title',
     icon: <IconSectionSign size={20} />,
     to: '/legal-notice',
-    description: 'footer.legalNotice.description',
     rights: [],
   },
   {


### PR DESCRIPTION
## DESCRIPTION

Implements sample pages in app for privacy policy and legal notice.

### TO-DO

- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #651
