### PR TITLE
fix: set only name and mail as required in contact data

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -1,10 +1,11 @@
 # Migrations
 
-## [7.10.X (XX.XX.XXXX)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.10.0...essencium-app-v7.10.X)
+## [8.0.1 (27.03.2025)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v7.10.0...essencium-app-v8.0.1)
 
 ### `src/app/[locale]/(main)/contact/ContactView.tsx`
 
 - Inputfields `name` and `mailAdress` have been removed from the contactForm and therefore the values must be set in the sendMessage request.
+- `contactPerson` is required as prop for `<Contact/>` with minimum name and phone number.
 
 ### `public/locales/(de|en)/common.json`
 

--- a/packages/lib/src/components/Contact/Contact.tsx
+++ b/packages/lib/src/components/Contact/Contact.tsx
@@ -27,13 +27,13 @@ import { ContactForm, ContactPersonCard } from './components'
 type Props = {
   control: Control<ContactFormType>
   formState: FormState<ContactFormType>
-  contactPerson?: ContactPerson
+  contactPerson: ContactPerson
 }
 
 export function Contact({
   control,
   formState,
-  contactPerson = undefined,
+  contactPerson,
 }: Props): JSX.Element {
   return (
     <Grid role="grid">

--- a/packages/lib/src/components/Contact/components/ContactPersonCard.tsx
+++ b/packages/lib/src/components/Contact/components/ContactPersonCard.tsx
@@ -26,6 +26,7 @@ import {
   Text,
   ThemeIcon,
   Title,
+  useMantineTheme,
 } from '@mantine/core'
 import {
   IconBrandInstagram,
@@ -41,20 +42,13 @@ import type { JSX } from 'react'
 import classes from './ContactPersonCard.module.css'
 
 type Props = {
-  contactPerson?: ContactPerson
+  contactPerson: ContactPerson
 }
 
 export function ContactPersonCard({ contactPerson }: Props): JSX.Element {
   const { t } = useTranslation()
 
-  const examplePerson = {
-    name: 'Jane Doe',
-    phone: '+1(123) 456-7890',
-    email: 'jane.doe@example.com',
-    address: '123 Maple Street. Anytown, PA 17101',
-    linkedinUrl: 'https://www.linkedin.com/company/frachtwerk',
-    instagramUrl: 'https://www.instagram.com/frachtwerk.de/',
-  }
+  const theme = useMantineTheme()
 
   return (
     <Card
@@ -73,34 +67,36 @@ export function ContactPersonCard({ contactPerson }: Props): JSX.Element {
         <Avatar
           size="xl"
           // color gets not applied when outsourced to module.css
-          color="var(--mantine-color-blue-6)"
-          name={contactPerson?.name ?? examplePerson.name}
+          color={theme.primaryColor}
+          name={contactPerson.name}
           className={classes['contact-person-card__avatar']}
         />
 
         <Title order={5} className={classes['contact-person-card__title']}>
-          {contactPerson?.name ?? examplePerson.name}
+          {contactPerson.name}
         </Title>
 
         <Flex direction="column" align="flex-start" gap="sm">
-          <Group
-            gap="xl"
-            aria-label={
-              t(
-                'contactView.contactPersonCard.contactPerson.ariaLabel',
-              ) as string
-            }
-          >
-            <ThemeIcon
-              className={classes['contact-person-card__theme-icon--radius']}
+          {contactPerson?.phone ? (
+            <Group
+              gap="xl"
+              aria-label={
+                t(
+                  'contactView.contactPersonCard.contactPerson.ariaLabel',
+                ) as string
+              }
             >
-              <IconPhoneCall
-                className={classes['contact-person-card__icon--size']}
-              />
-            </ThemeIcon>
+              <ThemeIcon
+                className={classes['contact-person-card__theme-icon--radius']}
+              >
+                <IconPhoneCall
+                  className={classes['contact-person-card__icon--size']}
+                />
+              </ThemeIcon>
 
-            <Text>{contactPerson?.phone ?? examplePerson.phone}</Text>
-          </Group>
+              <Text>{contactPerson.phone}</Text>
+            </Group>
+          ) : null}
 
           <Group gap="xl" aria-label="Contact info">
             <ThemeIcon
@@ -111,55 +107,55 @@ export function ContactPersonCard({ contactPerson }: Props): JSX.Element {
               />
             </ThemeIcon>
 
-            <Text>{contactPerson?.email ?? examplePerson.email}</Text>
+            <Text>{contactPerson.email}</Text>
           </Group>
 
-          <Group gap="xl" aria-label="Contact info">
-            <ThemeIcon
-              className={classes['contact-person-card__theme-icon--radius']}
-            >
-              <IconLocation
-                className={classes['contact-person-card__icon--size']}
-              />
-            </ThemeIcon>
+          {contactPerson?.address ? (
+            <Group gap="xl" aria-label="Contact info">
+              <ThemeIcon
+                className={classes['contact-person-card__theme-icon--radius']}
+              >
+                <IconLocation
+                  className={classes['contact-person-card__icon--size']}
+                />
+              </ThemeIcon>
 
-            <Text>{contactPerson?.address ?? examplePerson.address}</Text>
-          </Group>
+              <Text>{contactPerson.address}</Text>
+            </Group>
+          ) : null}
         </Flex>
 
         <Group
           className={classes['contact-person-card__group']}
           aria-label="Contact info"
         >
-          <NextLink
-            href={contactPerson?.linkedinUrl ?? examplePerson.linkedinUrl}
-            passHref
-          >
-            <ThemeIcon
-              variant="light"
-              className={classes['contact-person-card__theme-icon--radius']}
-            >
-              <IconBrandLinkedin
-                className={classes['contact-person-card__icon--size']}
-                aria-label="Social icon"
-              />
-            </ThemeIcon>
-          </NextLink>
+          {contactPerson?.linkedinUrl ? (
+            <NextLink href={contactPerson.linkedinUrl} passHref>
+              <ThemeIcon
+                variant="light"
+                className={classes['contact-person-card__theme-icon--radius']}
+              >
+                <IconBrandLinkedin
+                  className={classes['contact-person-card__icon--size']}
+                  aria-label="Social icon"
+                />
+              </ThemeIcon>
+            </NextLink>
+          ) : null}
 
-          <NextLink
-            href={contactPerson?.instagramUrl ?? examplePerson.instagramUrl}
-            passHref
-          >
-            <ThemeIcon
-              variant="light"
-              className={classes['contact-person-card__theme-icon--radius']}
-            >
-              <IconBrandInstagram
-                className={classes['contact-person-card__icon--size']}
-                aria-label="Social icon"
-              />
-            </ThemeIcon>
-          </NextLink>
+          {contactPerson.instagramUrl ? (
+            <NextLink href={contactPerson.instagramUrl} passHref>
+              <ThemeIcon
+                variant="light"
+                className={classes['contact-person-card__theme-icon--radius']}
+              >
+                <IconBrandInstagram
+                  className={classes['contact-person-card__icon--size']}
+                  aria-label="Social icon"
+                />
+              </ThemeIcon>
+            </NextLink>
+          ) : null}
         </Group>
       </Flex>
     </Card>

--- a/packages/types/src/contact.ts
+++ b/packages/types/src/contact.ts
@@ -29,8 +29,8 @@ export type ContactFormType = z.infer<typeof contactFormSchema>
 export type ContactPerson = {
   name: string
   email: string
-  phone: string | null
-  address: string | null
-  linkedinUrl: string | null
-  instagramUrl: string | null
+  phone?: string
+  address?: string
+  linkedinUrl?: string
+  instagramUrl?: string
 }


### PR DESCRIPTION
## DESCRIPTION

Currently telephone, address, and social media is required for contact. Values can be set du null but then defaults will be used. 
Instead there should be a minimum of required values (mail and name) and everything thats not set is not rendered.

### TO-DO

- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment


