### PR TITLE
prevent NavBar pin icon from disappearing

### DIFF
--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -287,12 +287,14 @@ export function AuthLayout({ children, ...props }: Props): JSX.Element | null {
   }, [currentLocale, addTranslations])
 
   useEffect(() => {
-    if (!isNotMobile) {
-      setIsFoldedNav(false)
-    } else {
-      setIsFoldedNav(true)
+    if (!isFixedNav) {
+      if (!isNotMobile) {
+        setIsFoldedNav(false)
+      } else {
+        setIsFoldedNav(true)
+      }
     }
-  }, [isNotMobile])
+  }, [isFixedNav, isNotMobile])
 
   return (
     <>


### PR DESCRIPTION
## DESCRIPTION

If the navBar is unfolded and fixed and the screen size changes to mobile and back, the pin icon disappears.

### TO-DO

- [ ] fix condition logic

### CLOSES

[#742](https://github.com/Frachtwerk/essencium-frontend/issues/742#event-17008764480)
