### PR TITLE
758 child navitems not accessible in e2e tests and mobile view

### DIFF
--- a/packages/lib/src/components/Header/components/UserMenu/UserMenu.tsx
+++ b/packages/lib/src/components/Header/components/UserMenu/UserMenu.tsx
@@ -41,9 +41,10 @@ type Props = {
     group?: string
     mail?: string
   }
+  avatarColor?: string
 }
 
-export function UserMenu({ user, className }: Props): JSX.Element {
+export function UserMenu({ user, className, avatarColor }: Props): JSX.Element {
   const { t } = useTranslation()
 
   const theme = useMantineTheme()
@@ -67,7 +68,7 @@ export function UserMenu({ user, className }: Props): JSX.Element {
           size="md"
           radius="lg"
           name={`${user.firstName} ${user.lastName}`}
-          color={theme.primaryColor}
+          color={avatarColor ?? theme.primaryColor}
         />
 
         <Box className={classes['user-menu__box']}>

--- a/packages/lib/src/components/NavBar/components/NavLinks.tsx
+++ b/packages/lib/src/components/NavBar/components/NavLinks.tsx
@@ -56,14 +56,43 @@ export function NavLinks({
 
   return (
     <>
-      {links.map(link =>
-        !link.rights.length ||
-        (link.rights && hasRequiredRights(userRights, link.rights)) ? (
+      {links.map(link => {
+        const isParentLink = link.navLinks?.length
+
+        // Check if the link is a parent link
+        if (!isParentLink) {
+          return !link.rights.length ||
+            (link.rights && hasRequiredRights(userRights, link.rights)) ? (
+            <MantineNavLink
+              component={NextLink}
+              href={link.to}
+              target={link?.isExternalLink ? '_blank' : '_self'}
+              key={link.label}
+              leftSection={link.icon}
+              label={t(link.label)}
+              active={isLinkActive(link.to) || isSubLinkActive(link.navLinks)}
+              color={
+                isLinkActive(link.to)
+                  ? undefined
+                  : 'var(--mantine-color-gray-9)'
+              }
+              className={classes['nav-bar__navlink']}
+              classNames={{
+                root: classes['nav-bar__navlink--root'],
+                label: classes['nav-bar__navlink--label'],
+              }}
+              onClick={() => handleOpenNav()}
+              prefetch={link.prefetch ?? true}
+            />
+          ) : null
+        }
+
+        // if link is a parent link display it as a button without href & co. and add sublinks
+        return !link.rights.length ||
+          (link.rights && hasRequiredRights(userRights, link.rights)) ? (
           <MantineNavLink
-            component={NextLink}
+            component="button"
             key={link.label}
-            href={link.to}
-            target={link?.isExternalLink ? '_blank' : '_self'}
             leftSection={link.icon}
             label={t(link.label)}
             active={isLinkActive(link.to) || isSubLinkActive(link.navLinks)}
@@ -75,8 +104,6 @@ export function NavLinks({
               root: classes['nav-bar__navlink--root'],
               label: classes['nav-bar__navlink--label'],
             }}
-            onClick={() => !link.navLinks?.length && handleOpenNav()}
-            prefetch={link.prefetch ?? true}
           >
             {!foldedNav
               ? link.navLinks?.map(sublink =>
@@ -103,8 +130,8 @@ export function NavLinks({
                 )
               : null}
           </MantineNavLink>
-        ) : null,
-      )}
+        ) : null
+      })}
     </>
   )
 }


### PR DESCRIPTION
## DESCRIPTION

Links with sublinks are handled as buttons, all other (normal links, sublinks themselves) are handled as NextLink.

### TO-DO

- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes https://github.com/Frachtwerk/essencium-frontend/issues/758
