### PR TITLE
fix(frontend): fix sorting by name of user table (#772)

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -34,6 +34,12 @@
 - remove attribute `className` from `AppShell`
 - add attribute `padding="lg"` to `AppShell`
 
+### Fix sorting of user table by name
+
+#### `src/app/[locale]/(main)/admin/users/UsersView.tsx`
+
+- fix `accessorKey` for column `name`
+
 ## [8.1.1 (08.04.2025)](https://github.com/Frachtwerk/essencium-frontend/compare/essencium-app-v8.1.0...essencium-app-v8.1.1)
 
 ### Fix Translation

--- a/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
@@ -206,7 +206,7 @@ export default function UsersView(): JSX.Element {
         enableColumnFilter: false,
       },
       {
-        accessorKey: 'name',
+        accessorKey: 'firstName',
         header: () => <Text inherit>{t('usersView.table.name')}</Text>,
         cell: info => {
           const rowUser = info.row.original


### PR DESCRIPTION
## DESCRIPTION

This fixes the sorting of the user table by name.
The property `name` does not exist in the backend payload, instead either `firstName` or `lastName` have to be used. As the default sorting is done by `firstName`, I picked it here as well.

A test for this will be added in the scope of #682.

### CLOSES

closes #772 