### PR TITLE
fix(frontend): fix vulnerability in vite package

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -78,7 +78,7 @@
     "eslint-plugin-simple-import-sort": "10.0.0",
     "postcss-preset-mantine": "1.17.0",
     "prettier": "3.0.3",
-    "vite": "6.2.6",
+    "vite": "6.2.7",
     "vitest": "3.0.7"
   },
   "engines": {

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -102,7 +102,7 @@
     "rollup-plugin-postcss": "4.0.2",
     "tslib": "2.5.3",
     "typescript": "5.7.3",
-    "vite": "6.2.6",
+    "vite": "6.2.7",
     "vitest": "3.0.7",
     "zod": "3.22.5"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,7 +231,7 @@ importers:
         version: 7.18.0(eslint@8.56.0)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1))
+        version: 4.3.4(vite@6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1))
       eslint:
         specifier: 8.56.0
         version: 8.56.0
@@ -269,8 +269,8 @@ importers:
         specifier: 3.0.3
         version: 3.0.3
       vite:
-        specifier: 6.2.6
-        version: 6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
+        specifier: 6.2.7
+        version: 6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
       vitest:
         specifier: 3.0.7
         version: 3.0.7(@types/node@20.11.30)(happy-dom@15.10.8)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
@@ -409,7 +409,7 @@ importers:
         version: 7.18.0(eslint@8.56.0)(typescript@5.7.3)
       '@vitejs/plugin-react':
         specifier: 4.3.4
-        version: 4.3.4(vite@6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))
+        version: 4.3.4(vite@6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))
       '@vitest/coverage-v8':
         specifier: 3.0.7
         version: 3.0.7(vitest@3.0.7(@types/node@20.14.14)(happy-dom@15.10.8)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))
@@ -516,8 +516,8 @@ importers:
         specifier: 5.7.3
         version: 5.7.3
       vite:
-        specifier: 6.2.6
-        version: 6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
+        specifier: 6.2.7
+        version: 6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
       vitest:
         specifier: 3.0.7
         version: 3.0.7(@types/node@20.14.14)(happy-dom@15.10.8)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
@@ -4561,8 +4561,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@6.2.6:
-    resolution: {integrity: sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==}
+  vite@6.2.7:
+    resolution: {integrity: sha512-qg3LkeuinTrZoJHHF94coSaTfIPyBYoywp+ys4qu20oSJFbKMYoIJo0FWJT9q6Vp49l6z9IsJRbHdcGtiKbGoQ==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -5917,25 +5917,25 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1))':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
+      vite: 6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.3.4(vite@6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))':
+  '@vitejs/plugin-react@4.3.4(vite@6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
+      vite: 6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -5964,21 +5964,21 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.0.7(vite@6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1))':
+  '@vitest/mocker@3.0.7(vite@6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
+      vite: 6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
 
-  '@vitest/mocker@3.0.7(vite@6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))':
+  '@vitest/mocker@3.0.7(vite@6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))':
     dependencies:
       '@vitest/spy': 3.0.7
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
+      vite: 6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
 
   '@vitest/pretty-format@3.0.7':
     dependencies:
@@ -9138,7 +9138,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
+      vite: 6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9159,7 +9159,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
+      vite: 6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9174,7 +9174,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1):
+  vite@6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -9187,7 +9187,7 @@ snapshots:
       terser: 5.39.0
       yaml: 2.5.1
 
-  vite@6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1):
+  vite@6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1):
     dependencies:
       esbuild: 0.25.1
       postcss: 8.5.3
@@ -9203,7 +9203,7 @@ snapshots:
   vitest@3.0.7(@types/node@20.11.30)(happy-dom@15.10.8)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1))
+      '@vitest/mocker': 3.0.7(vite@6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -9219,7 +9219,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.6(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
+      vite: 6.2.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
       vite-node: 3.0.7(@types/node@20.11.30)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.5.3))(terser@5.39.0)(yaml@2.5.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -9242,7 +9242,7 @@ snapshots:
   vitest@3.0.7(@types/node@20.14.14)(happy-dom@15.10.8)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1):
     dependencies:
       '@vitest/expect': 3.0.7
-      '@vitest/mocker': 3.0.7(vite@6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))
+      '@vitest/mocker': 3.0.7(vite@6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1))
       '@vitest/pretty-format': 3.0.9
       '@vitest/runner': 3.0.7
       '@vitest/snapshot': 3.0.7
@@ -9258,7 +9258,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.6(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
+      vite: 6.2.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
       vite-node: 3.0.7(@types/node@20.14.14)(jiti@2.4.2)(sugarss@4.0.1(postcss@8.4.49))(terser@5.39.0)(yaml@2.5.1)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## DESCRIPTION

Vite package is updated to 6.2.7 to resolve this [CVE](https://github.com/Frachtwerk/essencium-frontend/security/dependabot/133).

### TO-DO

- [x] pull `main` & resolve merge conflicts
- [x] check Vercel deployment

### CLOSES

closes #792 
