### PR TITLE
682 enhance users view e2e tests

### DIFF
--- a/packages/app/e2e/UsersView.spec.ts
+++ b/packages/app/e2e/UsersView.spec.ts
@@ -103,11 +103,14 @@ test.describe('UsersView', () => {
   })
 
   test('sort users', async ({ page }) => {
-    await expectOrderOfUsers(page, [
-      'test.user@e2e.com',
-      'devnull@frachtwerk.de',
-      'andrii.udodenko@frachtwerk.de',
-    ])
+    // FIXME: as there are two users with firstname "Admin", the sorting is not reliable
+    // will be fixed with https://github.com/Frachtwerk/essencium-backend/issues/716
+
+    // await expectOrderOfUsers(page, [
+    //   'test.user@e2e.com',
+    //   'devnull@frachtwerk.de',
+    //   'andrii.udodenko@frachtwerk.de',
+    // ])
 
     await page.getByRole('cell', { name: 'Name' }).getByRole('img').click()
     await page.waitForResponse('**/v1/users?page=0&size=20&sort=firstName,desc')

--- a/packages/app/e2e/UsersView.spec.ts
+++ b/packages/app/e2e/UsersView.spec.ts
@@ -110,6 +110,7 @@ test.describe('UsersView', () => {
     ])
 
     await page.getByRole('cell', { name: 'Name' }).getByRole('img').click()
+    await page.waitForResponse('**/v1/users?page=0&size=20&sort=firstName,desc')
 
     await expectOrderOfUsers(page, [
       'devnull_user@frachtwerk.de',
@@ -118,6 +119,7 @@ test.describe('UsersView', () => {
     ])
 
     await page.getByRole('cell', { name: 'E-Mail' }).getByRole('img').click()
+    await page.waitForResponse('**/v1/users?page=0&size=20&sort=email,asc')
 
     await expectOrderOfUsers(page, [
       'andrii.udodenko@frachtwerk.de',
@@ -126,6 +128,7 @@ test.describe('UsersView', () => {
     ])
 
     await page.getByRole('cell', { name: 'E-Mail' }).getByRole('img').click()
+    await page.waitForResponse('**/v1/users?page=0&size=20&sort=email,desc')
 
     await expectOrderOfUsers(page, [
       'tuan.vu-extern@frachtwerk.de',
@@ -133,21 +136,12 @@ test.describe('UsersView', () => {
       'test.user@e2e.com',
     ])
 
+    // the exact sorting order is unreliable, so we just check that the correct requests have been made
     await page.getByRole('cell', { name: 'Active' }).getByRole('img').click()
-
-    await expectOrderOfUsers(page, [
-      'lea.kubis@frachtwerk.de',
-      'philipp.kaiser@frachtwerk.de',
-      'cathrin.truchan+1@frachtwerk.de',
-    ])
+    await page.waitForResponse('**/v1/users?page=0&size=20&sort=enabled,desc')
 
     await page.getByRole('cell', { name: 'Active' }).getByRole('img').click()
-
-    await expectOrderOfUsers(page, [
-      'fatma.alacayir@frachtwerk.de',
-      'duc-minh.tran@frachtwerk.de',
-      'devnull_user@frachtwerk.de',
-    ])
+    await page.waitForResponse('**/v1/users?page=0&size=20&sort=enabled,asc')
   })
 
   test('add, edit and delete user', async ({ page }) => {

--- a/packages/app/e2e/UsersView.spec.ts
+++ b/packages/app/e2e/UsersView.spec.ts
@@ -32,7 +32,7 @@ test.describe('UsersView', () => {
     ).toBeVisible()
   })
 
-  test.skip('add, edit and delete user', async ({ page }) => {
+  test('add, edit and delete user', async ({ page }) => {
     await page.getByRole('link', { name: 'Add User' }).click()
     await expect(page).toHaveURL('/admin/users/add')
 
@@ -55,7 +55,12 @@ test.describe('UsersView', () => {
 
     await expect(page).toHaveURL('/admin/users')
 
-    // FIXME: add filter to find the user by mail address
+    await page.getByText('Show filter').click()
+    await page
+      .getByRole('cell', { name: 'E-Mail' })
+      .getByPlaceholder('Search')
+      .fill('test@person.de')
+
     await expect(
       page.getByRole('cell', { name: 'Test Person', exact: true }),
     ).toBeVisible()
@@ -79,6 +84,12 @@ test.describe('UsersView', () => {
     await page.getByRole('button', { name: 'Save User' }).click()
 
     await page.waitForURL('/admin/users')
+
+    await page.getByText('Show filter').click()
+    await page
+      .getByRole('cell', { name: 'E-Mail' })
+      .getByPlaceholder('Search')
+      .fill('test@person.de')
 
     await expect(page.getByRole('cell', { name: '12345' })).toBeVisible()
 

--- a/packages/app/e2e/UsersView.spec.ts
+++ b/packages/app/e2e/UsersView.spec.ts
@@ -1,189 +1,125 @@
-import { expect, Page, test } from '@playwright/test'
+import { expect, Locator, Page, test } from '@playwright/test'
 
 import { BASE_URL } from '../playwright.config'
 
-async function expectOrderOfUsers(
-  page: Page,
-  expectedOrder: string[],
-): Promise<void> {
-  await Promise.all(
-    expectedOrder.map((name, index) =>
-      expect(page.locator(`tbody > tr:nth-child(${index + 1})`)).toContainText(
-        name,
-      ),
-    ),
-  )
+const EMAILS = {
+  adminUser: 'admin.user@e2e.com',
+  regularUser: 'regular.user@e2e.com',
+  testPerson: 'test@person.de',
+} as const
+
+function getCell(page: Page, name: string): Locator {
+  return page.getByRole('cell', { name })
 }
 
 test.describe('UsersView', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await page.goto(BASE_URL)
     await page
       .getByRole('button', { name: 'Show All Users', exact: true })
       .click()
-    await expect(page).toHaveURL('/admin/users')
+    await expect(page).toHaveURL(`${BASE_URL}/admin/users`)
   })
 
   test('go to usersView and render table', async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible()
-    await expect(
-      page.getByRole('columnheader', { name: 'Active' }).first(),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('columnheader', { name: 'Name', exact: true }),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('columnheader', { name: 'Phone' }),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('columnheader', { name: 'E-Mail' }),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('columnheader', { name: 'Language' }),
-    ).toBeVisible()
-    await expect(page.getByRole('columnheader', { name: 'Role' })).toBeVisible()
-    await expect(
-      page.getByRole('columnheader', { name: 'Actions' }),
-    ).toBeVisible()
+
+    const columnHeaders = [
+      'Active',
+      'Name',
+      'Phone',
+      'E-Mail',
+      'Language',
+      'Role',
+      'Actions',
+    ]
+
+    for (const header of columnHeaders) {
+      await expect(
+        page.getByRole('cell', { name: header, exact: header === 'Name' }),
+      ).toBeVisible()
+    }
   })
 
   test('filter users', async ({ page }) => {
     await page.getByText('Show filter').click()
 
-    await expect(
-      page.getByRole('cell', { name: 'Name' }).getByPlaceholder('Search'),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('cell', { name: 'E-Mail' }).getByPlaceholder('Search'),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('cell', { name: 'Roles' }).getByPlaceholder('Search'),
-    ).toBeVisible()
+    const filterColumns = ['Name', 'E-Mail', 'Roles']
 
-    await expect(
-      page.getByRole('cell', { name: 'andrii.udodenko@frachtwerk.de' }),
-    ).toBeVisible()
+    for (const column of filterColumns) {
+      await expect(
+        getCell(page, column).getByPlaceholder('Search'),
+      ).toBeVisible()
+    }
 
     // FIXME: searching by name is currently broken
 
-    await page
-      .getByRole('cell', { name: 'E-Mail' })
-      .getByPlaceholder('Search')
-      .fill('e2e.com')
-    await expect(
-      page.getByRole('cell', { name: 'test.user@e2e.com' }),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('cell', { name: 'andrii.udodenko@frachtwerk.de' }),
-    ).not.toBeVisible()
-    await page
-      .getByRole('cell', { name: 'E-Mail e2e.com' })
-      .getByRole('img')
-      .nth(1)
-      .click() // clear filter
+    await getCell(page, 'E-Mail').getByPlaceholder('Search').fill('e2e.com')
 
-    await expect(
-      page.getByRole('cell', { name: 'andrii.udodenko@frachtwerk.de' }),
-    ).toBeVisible()
+    await expect(getCell(page, EMAILS.adminUser)).toBeVisible()
 
-    await page
-      .getByRole('cell', { name: 'Roles' })
-      .getByPlaceholder('Search')
-      .click()
+    await getCell(page, 'E-Mail e2e.com').getByRole('img').nth(1).click() // clear filter
+
+    await getCell(page, 'Roles').getByPlaceholder('Search').click()
     await page.getByRole('option', { name: 'ADMIN' }).click()
-    await expect(
-      page.getByRole('cell', { name: 'devnull@frachtwerk.de' }),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('cell', { name: 'test.user@e2e.com' }),
-    ).toBeVisible()
-    await expect(
-      page.getByRole('cell', { name: 'andrii.udodenko@frachtwerk.de' }),
-    ).not.toBeVisible()
+
+    await expect(getCell(page, EMAILS.adminUser)).toBeVisible()
   })
 
   test('sort users', async ({ page }) => {
     // FIXME: as there are two users with firstname "Admin", the sorting is not reliable
     // will be fixed with https://github.com/Frachtwerk/essencium-backend/issues/716
 
-    // await expectOrderOfUsers(page, [
-    //   'test.user@e2e.com',
-    //   'devnull@frachtwerk.de',
-    //   'andrii.udodenko@frachtwerk.de',
-    // ])
-
-    await page.getByRole('cell', { name: 'Name' }).getByRole('img').click()
+    await getCell(page, 'Name').getByRole('img').click()
     await page.waitForResponse('**/v1/users?page=0&size=20&sort=firstName,desc')
 
-    await expectOrderOfUsers(page, [
-      'devnull_user@frachtwerk.de',
-      'tuan.vu-extern@frachtwerk.de',
-      'tobias.dillig@frachtwerk.de',
-    ])
-
-    await page.getByRole('cell', { name: 'E-Mail' }).getByRole('img').click()
+    await getCell(page, 'E-Mail').getByRole('img').click()
     await page.waitForResponse('**/v1/users?page=0&size=20&sort=email,asc')
 
-    await expectOrderOfUsers(page, [
-      'andrii.udodenko@frachtwerk.de',
-      'cathrin.truchan+100@frachtwerk.de',
-      'cathrin.truchan+1@frachtwerk.de',
-    ])
-
-    await page.getByRole('cell', { name: 'E-Mail' }).getByRole('img').click()
+    await getCell(page, 'E-Mail').getByRole('img').click()
     await page.waitForResponse('**/v1/users?page=0&size=20&sort=email,desc')
 
-    await expectOrderOfUsers(page, [
-      'tuan.vu-extern@frachtwerk.de',
-      'tobias.dillig@frachtwerk.de',
-      'test.user@e2e.com',
-    ])
-
     // the exact sorting order is unreliable, so we just check that the correct requests have been made
-    await page.getByRole('cell', { name: 'Active' }).getByRole('img').click()
+    await getCell(page, 'Active').getByRole('img').click()
     await page.waitForResponse('**/v1/users?page=0&size=20&sort=enabled,desc')
 
-    await page.getByRole('cell', { name: 'Active' }).getByRole('img').click()
+    await getCell(page, 'Active').getByRole('img').click()
     await page.waitForResponse('**/v1/users?page=0&size=20&sort=enabled,asc')
   })
 
   test('add, edit and delete user', async ({ page }) => {
     await page.getByRole('link', { name: 'Add User' }).click()
-    await expect(page).toHaveURL('/admin/users/add')
+    await expect(page).toHaveURL(`${BASE_URL}/admin/users/add`)
 
     await page.getByLabel('First Name').click()
-    await page.getByLabel('First Name').fill('Test')
+    await page.getByLabel('First Name').fill('Max')
     await page.getByLabel('First Name').press('Tab')
 
-    await page.getByLabel('Last Name').fill('Person')
+    await page.getByLabel('Last Name').fill('Müller')
     await page.getByLabel('Last Name').press('Tab')
 
-    await page.getByLabel('Email').fill('test@person.de')
+    await page.getByLabel('Email').fill(EMAILS.testPerson)
 
     await page.getByRole('textbox', { name: 'Role' }).click()
-
     await page.getByRole('option', { name: 'ADMIN' }).click()
 
     await page.getByRole('button', { name: 'Save User' }).click()
 
     await page.waitForTimeout(4000)
 
-    await expect(page).toHaveURL('/admin/users')
+    await expect(page).toHaveURL(`${BASE_URL}/admin/users`)
 
     await page.getByText('Show filter').click()
-    await page
-      .getByRole('cell', { name: 'E-Mail' })
+    await getCell(page, 'E-Mail')
       .getByPlaceholder('Search')
-      .fill('test@person.de')
+      .fill(EMAILS.testPerson)
 
     await expect(
-      page.getByRole('cell', { name: 'Test Person', exact: true }),
+      page.getByRole('cell', { name: 'Max Müller', exact: true }),
     ).toBeVisible()
 
     const editIcon = page
-      .getByRole('row', {
-        name: 'Test Person test@person.de',
-      })
+      .getByRole('row', { name: 'Max Müller test@person.de' })
       .getByRole('button')
       .first()
 
@@ -191,27 +127,24 @@ test.describe('UsersView', () => {
 
     await expect(page.getByText('Update a user').nth(1)).toBeVisible()
 
-    await expect(page.getByLabel('First Name')).toHaveValue('Test')
+    await expect(page.getByLabel('First Name')).toHaveValue('Max')
 
     await page.getByLabel('Phone Number').click()
     await page.getByLabel('Phone Number').fill('12345')
 
     await page.getByRole('button', { name: 'Save User' }).click()
 
-    await page.waitForURL('/admin/users')
+    await page.waitForURL(`${BASE_URL}/admin/users`)
 
     await page.getByText('Show filter').click()
-    await page
-      .getByRole('cell', { name: 'E-Mail' })
+    await getCell(page, 'E-Mail')
       .getByPlaceholder('Search')
-      .fill('test@person.de')
+      .fill(EMAILS.testPerson)
 
     await expect(page.getByRole('cell', { name: '12345' })).toBeVisible()
 
     const deleteIcon = page
-      .getByRole('row', {
-        name: 'Test Person 12345 test@person.de',
-      })
+      .getByRole('row', { name: 'Max Müller 12345 test@person.de' })
       .getByRole('button')
       .nth(1)
 
@@ -221,7 +154,7 @@ test.describe('UsersView', () => {
 
     await expect(
       page.getByRole('row', {
-        name: 'Test Person 12345 test@person.de',
+        name: 'Max Müller 12345 test@person.de',
         exact: true,
       }),
     ).not.toBeVisible()

--- a/packages/app/e2e/UsersView.spec.ts
+++ b/packages/app/e2e/UsersView.spec.ts
@@ -1,4 +1,19 @@
-import { expect, test } from '@playwright/test'
+import { expect, Page, test } from '@playwright/test'
+
+import { BASE_URL } from '../playwright.config'
+
+async function expectOrderOfUsers(
+  page: Page,
+  expectedOrder: string[],
+): Promise<void> {
+  await Promise.all(
+    expectedOrder.map((name, index) =>
+      expect(page.locator(`tbody > tr:nth-child(${index + 1})`)).toContainText(
+        name,
+      ),
+    ),
+  )
+}
 
 test.describe('UsersView', () => {
   test.beforeEach(async ({ page }) => {
@@ -30,6 +45,109 @@ test.describe('UsersView', () => {
     await expect(
       page.getByRole('columnheader', { name: 'Actions' }),
     ).toBeVisible()
+  })
+
+  test('filter users', async ({ page }) => {
+    await page.getByText('Show filter').click()
+
+    await expect(
+      page.getByRole('cell', { name: 'Name' }).getByPlaceholder('Search'),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('cell', { name: 'E-Mail' }).getByPlaceholder('Search'),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('cell', { name: 'Roles' }).getByPlaceholder('Search'),
+    ).toBeVisible()
+
+    await expect(
+      page.getByRole('cell', { name: 'andrii.udodenko@frachtwerk.de' }),
+    ).toBeVisible()
+
+    // FIXME: searching by name is currently broken
+
+    await page
+      .getByRole('cell', { name: 'E-Mail' })
+      .getByPlaceholder('Search')
+      .fill('e2e.com')
+    await expect(
+      page.getByRole('cell', { name: 'test.user@e2e.com' }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('cell', { name: 'andrii.udodenko@frachtwerk.de' }),
+    ).not.toBeVisible()
+    await page
+      .getByRole('cell', { name: 'E-Mail e2e.com' })
+      .getByRole('img')
+      .nth(1)
+      .click() // clear filter
+
+    await expect(
+      page.getByRole('cell', { name: 'andrii.udodenko@frachtwerk.de' }),
+    ).toBeVisible()
+
+    await page
+      .getByRole('cell', { name: 'Roles' })
+      .getByPlaceholder('Search')
+      .click()
+    await page.getByRole('option', { name: 'ADMIN' }).click()
+    await expect(
+      page.getByRole('cell', { name: 'devnull@frachtwerk.de' }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('cell', { name: 'test.user@e2e.com' }),
+    ).toBeVisible()
+    await expect(
+      page.getByRole('cell', { name: 'andrii.udodenko@frachtwerk.de' }),
+    ).not.toBeVisible()
+  })
+
+  test('sort users', async ({ page }) => {
+    await expectOrderOfUsers(page, [
+      'test.user@e2e.com',
+      'devnull@frachtwerk.de',
+      'andrii.udodenko@frachtwerk.de',
+    ])
+
+    await page.getByRole('cell', { name: 'Name' }).getByRole('img').click()
+
+    await expectOrderOfUsers(page, [
+      'devnull_user@frachtwerk.de',
+      'tuan.vu-extern@frachtwerk.de',
+      'tobias.dillig@frachtwerk.de',
+    ])
+
+    await page.getByRole('cell', { name: 'E-Mail' }).getByRole('img').click()
+
+    await expectOrderOfUsers(page, [
+      'andrii.udodenko@frachtwerk.de',
+      'cathrin.truchan+100@frachtwerk.de',
+      'cathrin.truchan+1@frachtwerk.de',
+    ])
+
+    await page.getByRole('cell', { name: 'E-Mail' }).getByRole('img').click()
+
+    await expectOrderOfUsers(page, [
+      'tuan.vu-extern@frachtwerk.de',
+      'tobias.dillig@frachtwerk.de',
+      'test.user@e2e.com',
+    ])
+
+    await page.getByRole('cell', { name: 'Active' }).getByRole('img').click()
+
+    await expectOrderOfUsers(page, [
+      'lea.kubis@frachtwerk.de',
+      'philipp.kaiser@frachtwerk.de',
+      'cathrin.truchan+1@frachtwerk.de',
+    ])
+
+    await page.getByRole('cell', { name: 'Active' }).getByRole('img').click()
+
+    await expectOrderOfUsers(page, [
+      'fatma.alacayir@frachtwerk.de',
+      'duc-minh.tran@frachtwerk.de',
+      'devnull_user@frachtwerk.de',
+    ])
   })
 
   test('add, edit and delete user', async ({ page }) => {


### PR DESCRIPTION
## DESCRIPTION

This PR fixes an existing test and adds tests for sorting and filtering users in the `UsersView`.

The sorting-test will be probably quite flaky, as the order will change when new users are added to LDAP. But I figured it'd be good to have a test for this for at least and plan to check how we can setup an own environment for e2e-tests.

### TODO

Based on and blocked by #789.

### RELATED ISSUE

Part of #682.
