### PR TITLE
feat(frontend): implement refresh token logic

### DIFF
--- a/packages/app/src/app/[locale]/(public)/login/LoginView.tsx
+++ b/packages/app/src/app/[locale]/(public)/login/LoginView.tsx
@@ -88,13 +88,7 @@ export default function LoginView(): JSX.Element {
   const [isPasswordResetFormOpened, setIsPasswordResetFormOpened] =
     useState(false)
 
-  const { mutate: createToken, data: tokenData } = useCreateToken()
-
-  const setToken = useSetAtom(authTokenAtom)
-
-  if (tokenData) {
-    setToken(tokenData.token)
-  }
+  const { mutate: createToken } = useCreateToken()
 
   function handleLogin(username: string, password: string): void {
     createToken(

--- a/packages/app/src/components/layouts/AuthLayout.tsx
+++ b/packages/app/src/components/layouts/AuthLayout.tsx
@@ -52,7 +52,7 @@ import { useTranslation } from 'react-i18next'
 import { useGetMe, userAtom, userRightsAtom } from '@/api'
 import { useCreateFeedback } from '@/api/feedback'
 import { theme } from '@/config'
-import { useAddTranslations } from '@/hooks'
+import { useAddTranslations, useScheduleTokenRenewal } from '@/hooks'
 import {
   isBrowserEnvironment,
   logout,
@@ -248,6 +248,8 @@ export function AuthLayout({ children, ...props }: Props): JSX.Element | null {
       setIsLoadingAuthToken(false)
     }
   }, [user, router, path])
+
+  useScheduleTokenRenewal()
 
   function handleLogout(): void {
     logout()

--- a/packages/app/src/hooks/index.ts
+++ b/packages/app/src/hooks/index.ts
@@ -18,4 +18,5 @@
  */
 
 export * from './useAddTranslation'
+export * from './useScheduleTokenRenewal'
 export * from './useZodForm'

--- a/packages/app/src/hooks/useScheduleTokenRenewal.ts
+++ b/packages/app/src/hooks/useScheduleTokenRenewal.ts
@@ -1,0 +1,39 @@
+// Call renewToken when the access token is nearing expiration (for example, 12 minutes before)
+import { useAtomValue } from 'jotai'
+import { useEffect, useRef } from 'react'
+
+import { authTokenAtom, useRenewToken } from '@/api'
+import { parseJwt } from '@/utils'
+
+export function useScheduleTokenRenewal(): void {
+  const token = useAtomValue(authTokenAtom)
+  const { mutate: renewToken } = useRenewToken()
+
+  const timerRef = useRef<number | undefined>(undefined)
+
+  useEffect(() => {
+    // Clear any previous timeout to avoid duplicates.
+    if (timerRef.current) {
+      clearTimeout(timerRef.current)
+    }
+
+    if (!token) return
+
+    const parsedToken = parseJwt(token)
+    if (!parsedToken || parsedToken.expiringIn <= 0) return
+
+    // Safe margin: when less than 12 minutes remain, renew the token.
+    const safeMargin = 1000 * 60 * 12 // 12 minutes
+    const timeoutDuration = Math.max(parsedToken.expiringIn - safeMargin, 0)
+
+    timerRef.current = window.setTimeout(() => {
+      // Invokes token renewal.
+      renewToken()
+    }, timeoutDuration)
+
+    // Cleanup: clear the timeout if the effect is re-run.
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current)
+    }
+  }, [token, renewToken])
+}

--- a/packages/app/src/utils/index.ts
+++ b/packages/app/src/utils/index.ts
@@ -20,5 +20,6 @@
 export * from './isBrowserEnvironment'
 export * from './logout'
 export * from './mergeTranslations'
+export * from './parseJwt'
 export * from './parseSorting'
 export * from './withBaseStylingShowNotification'

--- a/packages/app/src/utils/parseJwt.ts
+++ b/packages/app/src/utils/parseJwt.ts
@@ -1,0 +1,17 @@
+export function parseJwt(token: string): Record<string, number> | null {
+  try {
+    const base64Url = token.split('.')[1]
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    const jsonPayload = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map(c => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+        .join(''),
+    )
+    const parsedToken = JSON.parse(jsonPayload)
+    const expiringIn = new Date(parsedToken.exp * 1000).getTime() - Date.now()
+    return { expiringIn, ...parsedToken }
+  } catch (error) {
+    return null
+  }
+}


### PR DESCRIPTION
## DESCRIPTION

So for the refresh token logic there have to be two things sent with the post request at ```/auth/renew```. 
1. The valid (not expired) auth token
2. The refresh token cookie

I created the API call and also a new hook that is watching the remaining time to expire of the current auth token. 12 minutes before it expires a call is sent to ```/auth/renew```. 

Additionally moved the local storage logic for the auth token from the login component directly to the API call.

### TO-DO

- [ ] ~~implement and update tests~~
- [ ] ~~update docs~~
- [ ] pull `main` & resolve merge conflicts
- [ ] check Vercel deployment

### CLOSES

closes #581 