### PR TITLE
chore(e2e): configure playwright baseUrl

### DIFF
--- a/packages/app/e2e/HomeView.spec.ts
+++ b/packages/app/e2e/HomeView.spec.ts
@@ -1,10 +1,8 @@
 import { expect, test } from '@playwright/test'
 
-import { BASE_URL } from '../playwright.config'
-
 test.describe('HomeView', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(BASE_URL)
+    await page.goto('/')
   })
 
   test('go to homepage and open search bar', async ({ page }) => {
@@ -19,6 +17,6 @@ test.describe('HomeView', () => {
   test('go to homepage and use start menu', async ({ page }) => {
     const profileButton = page.getByLabel('View profile')
     await profileButton.click()
-    await expect(page).toHaveURL(`${BASE_URL}/profile`)
+    await expect(page).toHaveURL('/profile')
   })
 })

--- a/packages/app/e2e/LoginView.spec.ts
+++ b/packages/app/e2e/LoginView.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-import { ADMIN, BASE_URL } from '../playwright.config'
+import { ADMIN } from '../playwright.config'
 
 test('LoginView > redirect to login page', async ({ page }) => {
-  await page.goto(`${BASE_URL}/login`)
-  await expect(page).toHaveURL(`${BASE_URL}/login`)
+  await page.goto('/login')
+  await expect(page).toHaveURL('/login')
 
   await expect(page).toHaveTitle(/Login/)
   const heading = page.getByRole('heading', { name: 'Login' })
@@ -13,7 +13,7 @@ test('LoginView > redirect to login page', async ({ page }) => {
 
 test.describe('LoginView', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`${BASE_URL}/login`)
+    await page.goto('/login')
   })
 
   test('login', async ({ page }) => {
@@ -24,7 +24,7 @@ test.describe('LoginView', () => {
     await page.getByLabel('Password').fill(ADMIN.password)
 
     await page.getByRole('button', { name: 'Login' }).click()
-    await expect(page).toHaveURL(BASE_URL)
+    await expect(page).toHaveURL('/')
 
     await expect(page.locator('a').filter({ hasText: 'Logout' })).toBeVisible()
   })

--- a/packages/app/e2e/NavBar.spec.ts
+++ b/packages/app/e2e/NavBar.spec.ts
@@ -1,17 +1,15 @@
 import { expect, test } from '@playwright/test'
 
-import { BASE_URL } from '../playwright.config'
-
 // TODO: These tests rely on the UI being rendered in english.
 // Add separate test user that won't be used by actual users on Staging.
 test.describe('NavBar', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(BASE_URL)
+    await page.goto('/')
   })
 
   test('click through navigation', async ({ page }) => {
     await page.getByRole('link', { name: 'Home' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/`)
+    await expect(page).toHaveURL('/')
 
     const adminstrationMenu = page.getByRole('button', {
       name: 'Administration',
@@ -20,16 +18,16 @@ test.describe('NavBar', () => {
     await adminstrationMenu.click()
 
     await page.getByRole('link', { name: 'Users' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/admin/users`)
+    await expect(page).toHaveURL('/admin/users')
 
     await page.getByRole('link', { name: 'Roles' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/admin/roles`)
+    await expect(page).toHaveURL('/admin/roles')
 
     await page.getByRole('link', { name: 'Rights' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/admin/rights`)
+    await expect(page).toHaveURL('/admin/rights')
 
     await page.getByRole('link', { name: 'Translations' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/admin/translations`)
+    await expect(page).toHaveURL('/admin/translations')
 
     await expect(
       page.getByRole('link', { name: 'Privacy Policy' }),
@@ -38,7 +36,7 @@ test.describe('NavBar', () => {
     await expect(page.getByRole('link', { name: 'Legal Notice' })).toBeVisible()
 
     await page.getByRole('link', { name: 'Contact' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/contact`)
+    await expect(page).toHaveURL('/contact')
 
     await expect(page.locator('a').filter({ hasText: 'Logout' })).toBeVisible()
 

--- a/packages/app/e2e/ProfileView.spec.ts
+++ b/packages/app/e2e/ProfileView.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-import { ADMIN, BASE_URL } from '../playwright.config'
+import { ADMIN } from '../playwright.config'
 
 test.describe('ProfileView', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`${BASE_URL}/profile`)
+    await page.goto('/profile')
   })
 
   test('go to profile page and change name', async ({ page }) => {

--- a/packages/app/e2e/RightsView.spec.ts
+++ b/packages/app/e2e/RightsView.spec.ts
@@ -1,10 +1,8 @@
 import { expect, test } from '@playwright/test'
 
-import { BASE_URL } from '../playwright.config'
-
 test.describe('RightsView', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`${BASE_URL}/rights`)
+    await page.goto('/rights')
   })
 
   test('should render the rights view title', ({ page }) => {

--- a/packages/app/e2e/RolesView.spec.ts
+++ b/packages/app/e2e/RolesView.spec.ts
@@ -1,12 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-import { BASE_URL } from '../playwright.config'
-
 test.describe('RolesView', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(BASE_URL)
+    await page.goto('/')
     await page.getByRole('link', { name: 'Roles' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/roles`)
+    await expect(page).toHaveURL('/roles')
   })
 
   test.skip('open and close add role modal', async ({ page }) => {
@@ -45,7 +43,7 @@ test.describe('RolesView', () => {
     await saveButton.click()
 
     await page.waitForTimeout(4000)
-    await expect(page).toHaveURL(`${BASE_URL}/roles`)
+    await expect(page).toHaveURL('/roles')
 
     await expect(
       page.getByRole('cell', { name: 'TestRole', exact: true }),
@@ -65,7 +63,7 @@ test.describe('RolesView', () => {
     await updateRoleButton.click()
 
     await page.waitForTimeout(4000)
-    await expect(page).toHaveURL(`${BASE_URL}/roles`)
+    await expect(page).toHaveURL('/roles')
 
     await expect(
       page.getByRole('cell', { name: 'TestDescription edited', exact: true }),

--- a/packages/app/e2e/TranslationsView.spec.ts
+++ b/packages/app/e2e/TranslationsView.spec.ts
@@ -1,12 +1,10 @@
 import { expect, test } from '@playwright/test'
 
-import { BASE_URL } from '../playwright.config'
-
 test.describe('TranslationsView', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(BASE_URL)
+    await page.goto('/')
     await page.getByRole('link', { name: 'Translations' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/translations`)
+    await expect(page).toHaveURL('/translations')
   })
 
   // Commented out due to i18n issues, WIP

--- a/packages/app/e2e/UsersView.spec.ts
+++ b/packages/app/e2e/UsersView.spec.ts
@@ -1,14 +1,12 @@
 import { expect, test } from '@playwright/test'
 
-import { BASE_URL } from '../playwright.config'
-
 test.describe('UsersView', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(BASE_URL)
+    await page.goto('/')
     await page
       .getByRole('button', { name: 'Show All Users', exact: true })
       .click()
-    await expect(page).toHaveURL(`${BASE_URL}/admin/users`)
+    await expect(page).toHaveURL('/admin/users')
   })
 
   test('go to usersView and render table', async ({ page }) => {
@@ -26,7 +24,7 @@ test.describe('UsersView', () => {
 
   test.skip('add, edit and delete user', async ({ page }) => {
     await page.getByRole('link', { name: 'Add User' }).click()
-    await expect(page).toHaveURL(`${BASE_URL}/admin/users/add`)
+    await expect(page).toHaveURL('/admin/users/add')
 
     await page.getByLabel('First Name').click()
     await page.getByLabel('First Name').fill('Test')
@@ -45,7 +43,7 @@ test.describe('UsersView', () => {
 
     await page.waitForTimeout(4000)
 
-    await expect(page).toHaveURL(`${BASE_URL}/admin/users`)
+    await expect(page).toHaveURL('/admin/users')
 
     // FIXME: add filter to find the user by mail address
     await expect(
@@ -70,7 +68,7 @@ test.describe('UsersView', () => {
 
     await page.getByRole('button', { name: 'Save User' }).click()
 
-    await page.waitForURL(`${BASE_URL}/admin/users`)
+    await page.waitForURL('/admin/users')
 
     await expect(page.getByRole('cell', { name: '12345' })).toBeVisible()
 

--- a/packages/app/e2e/title.spec.ts
+++ b/packages/app/e2e/title.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test } from '@playwright/test'
 
-import { BASE_URL, BASE_URL_DOCS } from '../playwright.config'
+import { BASE_URL_DOCS } from '../playwright.config'
 
 test('preview has title', async ({ page }) => {
-  await page.goto(BASE_URL)
+  await page.goto('/')
   await expect(page).toHaveTitle(/Home/)
 })
 
+// Either remove this test or move it to /packages/docs after fixing
 test.skip('docs have title', async ({ page }) => {
   await page.goto(BASE_URL_DOCS)
 

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -55,7 +55,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    baseURL: BASE_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/packages/app/playwright/auth.setup.ts
+++ b/packages/app/playwright/auth.setup.ts
@@ -1,11 +1,11 @@
 import { test as setup } from '@playwright/test'
 
-import { ADMIN, BASE_URL } from '../playwright.config'
+import { ADMIN } from '../playwright.config'
 
 const authFile = './playwright/.auth/user.json'
 
 setup('authenticate', async ({ page }) => {
-  await page.goto(`${BASE_URL}/login`)
+  await page.goto(`/login`)
   await page.getByLabel('E-Mail').click()
   await page.getByLabel('E-Mail').fill(ADMIN.username)
   await page.getByLabel('Password').click()
@@ -17,7 +17,7 @@ setup('authenticate', async ({ page }) => {
     .click()
   await page.getByRole('button', { name: 'Login' }).click()
 
-  await page.waitForURL(BASE_URL)
+  await page.waitForURL('/')
 
   await page.context().storageState({ path: authFile })
 })

--- a/packages/app/playwright/lang.setup.ts
+++ b/packages/app/playwright/lang.setup.ts
@@ -1,9 +1,7 @@
 import { test as setup } from '@playwright/test'
 
-import { BASE_URL } from '../playwright.config'
-
 setup('language settings', async ({ page }) => {
-  await page.goto(BASE_URL)
+  await page.goto('/')
   await page
     .getByLabel('Profil ansehen')
     .or(page.getByLabel('View profile'))
@@ -20,5 +18,5 @@ setup('language settings', async ({ page }) => {
     .getByRole('button', { name: 'Save Changes' })
     .or(page.getByRole('button', { name: 'Änderungen speichern' }))
     .click()
-  await page.goto(BASE_URL)
+  await page.goto('/')
 })


### PR DESCRIPTION
## DESCRIPTION

This PR configures the [baseUrl](https://playwright.dev/docs/test-webserver#adding-a-baseurl) for Playwright and removes the now unnecessary imports of our exported `BASE_URL`.

The only test that covers a different site is a skipped test in `title.spec.js` that checks the page title of our deployed docs. As the test currently fails (because our docs don't have a page title right now), it seems to be kind of unimportant and it would better be moved to `packages/docs`, I decided to ignore this for now.

### CLOSES

Closes #820.