### PR TITLE
824 add fullstack docker compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages ./packages
 COPY . .
 
+ARG NODE_ENV=production
+COPY ./packages/app/.env.${NODE_ENV}* ./packages/app/.env.local
+
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry during the build.

--- a/backend.docker-compose.yml
+++ b/backend.docker-compose.yml
@@ -1,0 +1,42 @@
+---
+services:
+  backend:
+    image: frachtwerk/essencium-backend-demo:unstable
+    restart: unless-stopped
+    environment:
+      SPRING_PROFILES_ACTIVE: development, postgres
+      APP_URL: localhost:8098
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/essencium
+      SPRING_DATASOURCE_USERNAME: essencium
+      SPRING_DATASOURCE_PASSWORD: essencium
+    volumes:
+      - data:/srv/data
+    ports:
+      - '8098:8098'
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: '4G'
+
+  db:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      TZ: Europe/Berlin
+      POSTGRES_DB: essencium
+      POSTGRES_USER: essencium
+      POSTGRES_PASSWORD: essencium
+    volumes:
+      - db:/var/lib/postgresql
+      - postgres-data:/var/lib/postgresql/data
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: '4G'
+
+volumes:
+  data:
+  db:
+  postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,16 @@
+include:
+  - backend.docker-compose.yml
 services:
   essencium-frontend:
     build:
       context: .
       dockerfile: ./Dockerfile
+      args:
+        NODE_ENV: test
+    restart: unless-stopped
     environment:
-      NODE_ENV: production
+      - NODE_ENV=test
     ports:
-      - 3000:3000
+      - '3000:3000'
+    depends_on:
+      - backend

--- a/packages/app/.env.development
+++ b/packages/app/.env.development
@@ -1,0 +1,10 @@
+# APPLICATION
+APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+API_URL=https://backend.staging.essencium.dev
+NEXT_PUBLIC_API_URL=https://backend.staging.essencium.dev
+
+OAUTH_REDIRECT_URI=https://staging.essencium.dev
+
+APP_ENV=development # development | acceptance | staging

--- a/packages/app/.env.production
+++ b/packages/app/.env.production
@@ -1,0 +1,10 @@
+# APPLICATION
+APP_URL=https://staging.essencium.dev
+NEXT_PUBLIC_APP_URL=https://staging.essencium.dev
+
+API_URL=https://backend.staging.essencium.dev
+NEXT_PUBLIC_API_URL=https://backend.staging.essencium.dev
+
+OAUTH_REDIRECT_URI=https://staging.essencium.dev
+
+APP_ENV=staging # development | acceptance | staging

--- a/packages/app/.env.test
+++ b/packages/app/.env.test
@@ -1,0 +1,10 @@
+# APPLICATION
+APP_URL=http://localhost:3000
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+API_URL=http://localhost:8098
+NEXT_PUBLIC_API_URL=http://localhost:8098
+
+OAUTH_REDIRECT_URI=http://localhost:8098
+
+APP_ENV=development # development | acceptance | staging

--- a/packages/app/e2e/NavBar.spec.ts
+++ b/packages/app/e2e/NavBar.spec.ts
@@ -17,16 +17,26 @@ test.describe('NavBar', () => {
     await expect(adminstrationMenu).toBeVisible()
     await adminstrationMenu.click()
 
-    await page.getByRole('link', { name: 'Users' }).click()
+    const usersMenuItem = page.getByRole('link', { name: 'Users' })
+    await expect(usersMenuItem).toBeVisible()
+    await usersMenuItem.click()
     await expect(page).toHaveURL('/admin/users')
 
-    await page.getByRole('link', { name: 'Roles' }).click()
+    const rolesMenuItem = page.getByRole('link', { name: 'Roles' })
+    await expect(rolesMenuItem).toBeVisible()
+    await rolesMenuItem.click()
     await expect(page).toHaveURL('/admin/roles')
 
-    await page.getByRole('link', { name: 'Rights' }).click()
+    const rightsMenuItem = page.getByRole('link', { name: 'Rights' })
+    await expect(rightsMenuItem).toBeVisible()
+    await rightsMenuItem.click()
     await expect(page).toHaveURL('/admin/rights')
 
-    await page.getByRole('link', { name: 'Translations' }).click()
+    const translationsMenuItem = page.getByRole('link', {
+      name: 'Translations',
+    })
+    await expect(translationsMenuItem).toBeVisible()
+    await translationsMenuItem.click()
     await expect(page).toHaveURL('/admin/translations')
 
     await expect(

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -15,7 +15,10 @@
     "preview": "next start",
     "sort-package-json": "sort-package-json",
     "test": "pnpm test:unit && pnpm test:e2e",
-    "test:e2e": "playwright test .",
+    "test:e2e": "NODE_ENV=development playwright test .",
+    "test:e2e:development": "NODE_ENV=development playwright test .",
+    "test:e2e:production": "NODE_ENV=production playwright test .",
+    "test:e2e:test": "NODE_ENV=test playwright test .",
     "test:unit": "vitest run",
     "test:unit:coverage": "vitest run --coverage",
     "test:unit:watch": "vitest watch"

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -8,6 +8,7 @@
     "clean": "rimraf dist node_modules",
     "clean:install": "pnpm clean && pnpm install",
     "dev": "next dev",
+    "dev:test": "NODE_ENV=test next dev",
     "format:check": "prettier --check .",
     "format:write": "prettier --write .",
     "lint": "next lint",

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -10,9 +10,11 @@ import path from 'path'
  * See https://playwright.dev/docs/test-configuration.
  */
 
-dotenv.config({ path: path.resolve(__dirname, '.env.local') })
+const NODE_ENV = process.env.NODE_ENV || 'development'
 
-export const BASE_URL = 'https://staging.essencium.dev'
+dotenv.config({ path: path.resolve(__dirname, `.env.${NODE_ENV}`) })
+dotenv.config({ path: path.resolve(__dirname, '.env.local') })
+dotenv.config({ path: path.resolve(__dirname, '.env') })
 
 export const BASE_URL_DOCS = 'https://docs.essencium.dev'
 
@@ -55,7 +57,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: BASE_URL,
+    baseURL: process.env.NEXT_PUBLIC_APP_URL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -124,8 +126,11 @@ export default defineConfig({
   // outputDir: 'test-results/',
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   port: 3000,
-  // },
+  webServer:
+    NODE_ENV === 'production'
+      ? undefined
+      : {
+          command: 'pnpm run dev',
+          url: 'http://localhost:3000',
+        },
 })


### PR DESCRIPTION
## DESCRIPTION

This PR adds environment files with variables that describe their environments as well as Docker Compose files to start either the backend stack (`backend.docker-compose.yml`, taken from the [example file](https://github.com/Frachtwerk/essencium-backend/blob/main/docker/docker-compose.yaml) in the backend-repo) or the full stack (`docker-compose.yml`).

Also, it adjusts our Playwright configuration to be able to pull in the environment variables according to the provided `NODE_ENV`.
*Something to note: By default, `NODE_ENV` will be `undefined` in Playwright and needs to be explicitly defined.*

## How to test

- Start the backend with `docker compose -f backend.docker-compose.yml up -d`
  - In `packages/app`, start the frontend with `pnpm dev:test`
  - Check that you can access Essencium on http://localhost:3000 connected to a fully local backend
- Start the full stack via Docker Compose with `docker compose up -d` (after stopping the previously started stack with `docker compose down` and canceling the local frontend dev build)
  - Check that you can access Essencium fully local on http://localhost:3000 again
- Check if the e2e-tests in the pipeline still run against the staging backend, but with a local webserver
  - New and improved: Changes in the frontend will now actually be tested against with this setup!

## Notes

`pnpm:e2e:test` will let the e2e-tests try to test against a fully local environment (local webServer + local backend) what will currently fail. This will be finished in #826 and #827.

### CLOSES

Closes #816 & #824