### PR TITLE
Backend init logout endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ node_modules
 dist
 .DS_Store
 .rollup.cache
-
+.idea/
 playwright/.auth

--- a/packages/app/src/utils/logout.ts
+++ b/packages/app/src/utils/logout.ts
@@ -17,8 +17,23 @@
  * along with Essencium Frontend. If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function logout(): void {
-  localStorage.removeItem('authToken')
+'use client'
 
+export function logout(): void {
+  const authToken = JSON.parse(localStorage.getItem('authToken') as string)
+  localStorage.removeItem('authToken')
   localStorage.removeItem('user')
+
+  const logoutUrl = 'http://localhost:8098/auth/logout'
+  const redirectUrl = 'https://localhost:3000/login'
+
+  if (authToken) {
+    fetch(`${logoutUrl}?redirectUrl=${encodeURIComponent(redirectUrl)}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+        'Content-Type': 'application/json',
+      },
+    })
+  }
 }


### PR DESCRIPTION
## DESCRIPTION

This code snippet should be the basis for calling the newly created logout endpoint in https://github.com/Frachtwerk/essencium-backend/pull/740. Open to-dos:

- [ ] Replace hard-coded `logoutUrl` with a dynamically generated string (`<backend-api-url>/auth/logout`)
- [ ] Replace hard-coded `redirectUrl` with a dynamically generated string (`<frontend-url>/login`)

### TO-DO

- [ ] implement and update tests
- [ ] update docs
- [ ] pull `main` & resolve merge conflicts
- [ ] check Vercel deployment

### CLOSES

closes _list of issues closed in this PR_
