### PR TITLE
fix(app): adjust users sorting by name

### DIFF
--- a/packages/app/MIGRATION.md
+++ b/packages/app/MIGRATION.md
@@ -138,6 +138,12 @@ Removed files are:
 
 - Changed Add User button to render a NextLink as polymorphic button
 
+### Fix sorting & filtering of user table by name
+
+#### `src/app/[locale]/(main)/admin/users/UsersView.tsx`
+
+- fix `accessorKey` for column `name` again after the backend now supports both filtering and sorting of users by their `name`-property
+
 ## [9.3.0 (2025-06-23)](https://github.com/Frachtwerk/essencium-frontend/releases/tag/essencium-app-v9.3.0)
 
 ### Add refresh token logic

--- a/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
+++ b/packages/app/src/app/[locale]/(main)/admin/users/UsersView.tsx
@@ -88,7 +88,7 @@ export const FORM_DEFAULTS_USERS_VIEW = {
   roles: [ROLES.USER],
 }
 
-const DEFAULT_SORTING: SortingState = [{ id: 'firstName', desc: false }]
+const DEFAULT_SORTING: SortingState = [{ id: 'name', desc: false }]
 
 export default function UsersView(): JSX.Element {
   const userRights = useAtomValue(userRightsAtom)
@@ -193,7 +193,7 @@ export default function UsersView(): JSX.Element {
         enableColumnFilter: false,
       },
       {
-        accessorKey: 'firstName',
+        accessorKey: 'name',
         header: () => <Text inherit>{t('usersView.table.name')}</Text>,
         cell: info => {
           const rowUser = info.row.original


### PR DESCRIPTION
## DESCRIPTION

This PR essentially reverts the changes from #773.

In https://github.com/Frachtwerk/essencium-backend/pull/721, the missing support for sorting by the `name`-property has been added, so now both sorting and filtering of users do work by `name`.

### TO-DO

- [x] update MIGRATION.MD

### CLOSES

Closes #783.
