### PR TITLE
chore(devops): use docker hardened images as base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,6 +210,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login Docker Hardened Images registry
+        uses: docker/login-action@v3
+        with:
+          registry: dhi.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,8 @@
 # Based on the official Next.js Dockerfile example
 # https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
 
-FROM node:lts-alpine3.21 AS base
-
 # Install dependencies only when needed
-FROM base AS deps
+FROM dhi.io/node:24-alpine3.23-dev AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
@@ -21,7 +19,7 @@ RUN --mount=type=cache,id=pnpm,target=/root/.local/share/pnpm/store \
     pnpm i --frozen-lockfile --store-dir=/root/.local/share/pnpm/store;
 
 # Rebuild the source code only when needed
-FROM base AS builder
+FROM dhi.io/node:24-alpine3.23-dev AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/packages ./packages
@@ -38,32 +36,31 @@ COPY ./packages/app/.env.${NODE_ENV}* ./packages/app/.env.local
 RUN corepack enable pnpm && pnpm run build;
 
 # Production image, copy all the files and run next
-FROM base AS runner
+FROM dhi.io/node:24-alpine3.23 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+ENV HOSTNAME="0.0.0.0"
+ENV PORT=3000
 # Uncomment the following line in case you want to disable telemetry during runtime.
 # ENV NEXT_TELEMETRY_DISABLED=1
-
-RUN addgroup --system --gid 1001 nodejs
-RUN adduser --system --uid 1001 nextjs
 
 # Automatically leverage output traces to reduce image size
 # https://nextjs.org/docs/advanced-features/output-file-tracing
 
 # Standalone build output is spread across multiple directories for monorepos.
 # See https://github.com/vercel/next.js/discussions/35437
-COPY --from=builder --chown=nextjs:nodejs /app/packages/app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/packages/app/public ./packages/app/public
-COPY --from=builder --chown=nextjs:nodejs /app/packages/app/.next/static ./packages/app/.next/static
+COPY --from=builder --chown=node:node /app/packages/app/.next/standalone ./
+COPY --from=builder --chown=node:node /app/packages/app/public ./packages/app/public
+COPY --from=builder --chown=node:node /app/packages/app/.next/static ./packages/app/.next/static
 
-USER nextjs
+USER node
 
 EXPOSE 3000
 
-ENV PORT=3000
+HEALTHCHECK --interval=60s --timeout=30s --start-period=30s --retries=3 \
+    CMD ["node", "-e", "require('http').get('http://localhost:3000/api/health', res => process.exit(res.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"]
 
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/config/next-config-js/output
-ENV HOSTNAME="0.0.0.0"
 CMD ["node", "./packages/app/server.js"]

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -25,3 +25,47 @@ The package called app is acting as boilerplate and consumes all the other packa
 - routing (via Next.js App Router)
 - error logging (via Sentry)
 - E2E tests (via Playwright)
+
+## Starting the application locally
+
+### Prerequisites
+
+Before starting the application, make sure to complete the setup steps outlined below:
+
+### Docker
+
+To start the application locally, a full Docker environment is available.
+
+#### Authentication
+
+The images are based on [Docker hardened images](https://github.com/docker-hardened-images) that require authentication to pull.  
+Login with the following command using your Docker Hub credentials (username and [PAT](https://docs.docker.com/security/access-tokens/#create-a-personal-access-token)):
+
+```bash
+docker login dhi.io
+```
+
+#### Docker BuildX
+
+To build the images, Docker Buildx is required. You can check if it is available with the following command:
+
+```bash
+docker buildx version
+```
+
+If it is not available, you can install it by following the instructions in the [Docker Buildx documentation](https://github.com/docker/buildx?tab=readme-ov-file#installing).
+
+#### Starting the application
+
+To start the full application, run the following command in the root directory of the repository:
+
+```bash
+docker compose up --build
+```
+
+This will build the images based on the current code and start the application.  
+The following services will be started:
+
+- `backend`: The API service that handles the business logic and communication with the database. Available at http://localhost:8098.
+- `db`: The PostgreSQL database that stores the application data. Available at http://localhost:5432.
+- `essencium-frontend`: The Next.js frontend that provides the user interface. Available at localhost:3000.

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -67,5 +67,5 @@ This will build the images based on the current code and start the application.
 The following services will be started:
 
 - `backend`: The API service that handles the business logic and communication with the database. Available at http://localhost:8098.
-- `db`: The PostgreSQL database that stores the application data. Available at http://localhost:5432.
+- `db`: The PostgreSQL database that stores the application data. Available at localhost:5432.
 - `essencium-frontend`: The Next.js frontend that provides the user interface. Available at localhost:3000.


### PR DESCRIPTION
## DESCRIPTION

This PR rebases the `app` Dockerfile on the new [Docker hardened image](https://www.docker.com/blog/docker-hardened-images-for-every-developer/).

No functional changes have been added besides a new `HEALTHCHECK`.  
This one had to be done using `node` with inlined JavaScript, as the runtime hardened images contain neither `curl` nor `wget`.

## How to test

- Build the frontend locally with the help of the documentation
- Do a quick smoke test if it works as expected
- Checke if the documentation is missing any important information

### CLOSES

closes #953 